### PR TITLE
[FEAT] 동아리 탐색 기능 구현

### DIFF
--- a/club-service/src/main/java/club/gach_dong/Application.java
+++ b/club-service/src/main/java/club/gach_dong/Application.java
@@ -2,8 +2,10 @@ package club.gach_dong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class Application {
 
 	public static void main(String[] args) {

--- a/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
@@ -1,17 +1,16 @@
 package club.gach_dong.api;
 
 
+import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ArrayResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "동아리 API", description = "동아리 관련 API")
 @RestController
@@ -29,10 +28,19 @@ public interface ClubApiSpecification {
             summary = "동아리 조회",
             description = "동아리 이름을 이용하여 동아리 정보를 조회합니다."
     )
-    @GetMapping("/{clubName}")
+    @GetMapping("/{clubId}")
     ClubResponse getClub(
-            @Parameter(description = "동아리 이름", example = "GDSC", required = true)
-            @PathVariable
-            String clubName
+            @Parameter(description = "동아리 ID", example = "ansier-enicsei-1233na-bndknar", required = true)
+            @PathVariable String clubId
+    );
+
+    @Operation(
+            summary = "동아리 생성",
+            description = "동아리 정보를 입력받아 동아리를 생성합니다."
+    )
+    @PostMapping("/create")
+    ResponseEntity<ClubResponse> createClub(
+            @RequestBody(required = true)
+            CreateClubRequest createClubRequest
     );
 }

--- a/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
@@ -8,6 +8,7 @@ import club.gach_dong.dto.response.ClubSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -40,7 +41,8 @@ public interface ClubApiSpecification {
     )
     @PostMapping("/create")
     ResponseEntity<ClubResponse> createClub(
-            @RequestBody(required = true)
+            @Valid
+            @RequestBody
             CreateClubRequest createClubRequest
     );
 }

--- a/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
@@ -2,10 +2,7 @@ package club.gach_dong.api;
 
 
 import club.gach_dong.dto.request.CreateClubRequest;
-import club.gach_dong.dto.response.ArrayResponse;
-import club.gach_dong.dto.response.ClubActivityResponse;
-import club.gach_dong.dto.response.ClubResponse;
-import club.gach_dong.dto.response.ClubSummaryResponse;
+import club.gach_dong.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -57,4 +54,13 @@ public interface ClubApiSpecification {
             @PathVariable String clubId
     );
 
+    @Operation(
+            summary = "동아리 연락처 정보 조회",
+            description = "동아리 연락처 정보를 조회합니다."
+    )
+    @GetMapping("/{clubId}/contact-info")
+    ArrayResponse<ClubContactInfoResponse> getClubContactInfo(
+            @Parameter(description = "동아리 ID", example = "ansier-enicsei-1233na-bndknar", required = true)
+            @PathVariable String clubId
+    );
 }

--- a/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubApiSpecification.java
@@ -3,6 +3,7 @@ package club.gach_dong.api;
 
 import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ArrayResponse;
+import club.gach_dong.dto.response.ClubActivityResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,4 +46,15 @@ public interface ClubApiSpecification {
             @RequestBody
             CreateClubRequest createClubRequest
     );
+
+    @Operation(
+            summary = "동아리 활동 내역 조회",
+            description = "동아리 활동 내역을 조회합니다."
+    )
+    @GetMapping("/{clubId}/activities")
+    ArrayResponse<ClubActivityResponse> getClubActivities(
+            @Parameter(description = "동아리 ID", example = "ansier-enicsei-1233na-bndknar", required = true)
+            @PathVariable String clubId
+    );
+
 }

--- a/club-service/src/main/java/club/gach_dong/controller/ClubController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubController.java
@@ -3,6 +3,7 @@ package club.gach_dong.controller;
 import club.gach_dong.api.ClubApiSpecification;
 import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ArrayResponse;
+import club.gach_dong.dto.response.ClubActivityResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.service.ClubService;
@@ -36,5 +37,11 @@ public class ClubController implements ClubApiSpecification {
     public ResponseEntity<ClubResponse> createClub(CreateClubRequest createClubRequest) {
         ClubResponse clubResponse = clubService.createClub(createClubRequest);
         return new ResponseEntity<>(clubResponse, HttpStatus.CREATED);
+    }
+
+    @Override
+    public ArrayResponse<ClubActivityResponse> getClubActivities(String clubId) {
+        List<ClubActivityResponse> clubActivityResponse = clubService.getClubActivities(clubId);
+        return ArrayResponse.of(clubActivityResponse);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/controller/ClubController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubController.java
@@ -33,7 +33,7 @@ public class ClubController implements ClubApiSpecification {
     }
 
     @Override
-    public ResponseEntity<ClubResponse> createClub(@RequestBody @Validated CreateClubRequest createClubRequest) {
+    public ResponseEntity<ClubResponse> createClub(CreateClubRequest createClubRequest) {
         ClubResponse clubResponse = clubService.createClub(createClubRequest);
         return new ResponseEntity<>(clubResponse, HttpStatus.CREATED);
     }

--- a/club-service/src/main/java/club/gach_dong/controller/ClubController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubController.java
@@ -2,17 +2,12 @@ package club.gach_dong.controller;
 
 import club.gach_dong.api.ClubApiSpecification;
 import club.gach_dong.dto.request.CreateClubRequest;
-import club.gach_dong.dto.response.ArrayResponse;
-import club.gach_dong.dto.response.ClubActivityResponse;
-import club.gach_dong.dto.response.ClubResponse;
-import club.gach_dong.dto.response.ClubSummaryResponse;
+import club.gach_dong.dto.response.*;
 import club.gach_dong.service.ClubService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -43,5 +38,11 @@ public class ClubController implements ClubApiSpecification {
     public ArrayResponse<ClubActivityResponse> getClubActivities(String clubId) {
         List<ClubActivityResponse> clubActivityResponse = clubService.getClubActivities(clubId);
         return ArrayResponse.of(clubActivityResponse);
+    }
+
+    @Override
+    public ArrayResponse<ClubContactInfoResponse> getClubContactInfo(String clubId) {
+        List<ClubContactInfoResponse> clubContactInfoResponse = clubService.getClubContactInfo(clubId);
+        return ArrayResponse.of(clubContactInfoResponse);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/controller/ClubController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubController.java
@@ -1,12 +1,17 @@
 package club.gach_dong.controller;
 
 import club.gach_dong.api.ClubApiSpecification;
+import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ArrayResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.service.ClubService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -23,7 +28,13 @@ public class ClubController implements ClubApiSpecification {
     }
 
     @Override
-    public ClubResponse getClub(String clubName) {
-        return clubService.getClub(clubName);
+    public ClubResponse getClub(String clubId) {
+        return clubService.getClub(clubId);
+    }
+
+    @Override
+    public ResponseEntity<ClubResponse> createClub(@RequestBody @Validated CreateClubRequest createClubRequest) {
+        ClubResponse clubResponse = clubService.createClub(createClubRequest);
+        return new ResponseEntity<>(clubResponse, HttpStatus.CREATED);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/domain/Activity.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Activity.java
@@ -3,11 +3,13 @@ package club.gach_dong.domain;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
+@Getter
 @Table(name = "activity")
 @Schema(description = "동아리 활동 정보를 나타내는 엔티티")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/club-service/src/main/java/club/gach_dong/domain/Activity.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Activity.java
@@ -1,0 +1,47 @@
+package club.gach_dong.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "activity")
+@Schema(description = "동아리 활동 정보를 나타내는 엔티티")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Activity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "활동 ID", example = "1")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    @Schema(description = "활동 제목", example = "2023년 여름 프로젝트")
+    private String title;
+
+    @Column(name = "date", nullable = false)
+    @Schema(description = "활동 날짜", example = "2023-08-31")
+    private LocalDate date;
+
+    @Column(name = "description", nullable = false)
+    @Schema(description = "활동 설명", example = "팀별 프로젝트 진행 및 발표")
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    private Activity(String title, LocalDate date, String description, Club club) {
+        this.title = title;
+        this.date = date;
+        this.description = description;
+        this.club = club;
+    }
+
+    public static Activity of(String title, LocalDate date, String description, Club club) {
+        return new Activity(title, date, description, club);
+    }
+}

--- a/club-service/src/main/java/club/gach_dong/domain/Club.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Club.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +21,7 @@ public class Club {
     @Id
     @Column(name = "club_id", length = 36, columnDefinition = "CHAR(36)")
     @Schema(description = "동아리 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
     @Column(name = "club_name", length = 26, columnDefinition = "CHAR(26)")
@@ -62,14 +65,19 @@ public class Club {
     @Schema(description = "동아리 설립 날짜", example = "2020-03-15T10:15:30")
     private LocalDateTime establishedAt;
 
+    @CreatedDate
+    @Column(name = "created_at")
+    @Schema(description = "생성 날짜", example = "2023-10-24T12:00:00")
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
     @Column(name = "updated_at")
     @Schema(description = "마지막 업데이트 날짜", example = "2023-10-24T12:00:00")
     private LocalDateTime updatedAt;
 
-    private Club(String id, String name, ClubCategory category, String shortDescription, String introduction,
+    private Club(String name, ClubCategory category, String shortDescription, String introduction,
                  String clubImageUrl, boolean recruitingStatus, List<Activity> activities, List<Recruitment> recruitment,
-                 List<ContactInfo> contactInfo, LocalDateTime establishedAt, LocalDateTime updatedAt) {
-        this.id = id;
+                 List<ContactInfo> contactInfo, LocalDateTime establishedAt) {
         this.name = name;
         this.category = category;
         this.shortDescription = shortDescription;
@@ -80,14 +88,13 @@ public class Club {
         this.recruitment = recruitment;
         this.contactInfo = contactInfo;
         this.establishedAt = establishedAt;
-        this.updatedAt = updatedAt;
     }
 
-    public static Club of(String id, String name, ClubCategory category, String shortDescription, String introduction,
+    public static Club of(String name, ClubCategory category, String shortDescription, String introduction,
                           String clubImageUrl, boolean recruitingStatus, List<Activity> activities,
                           List<Recruitment> recruitment, List<ContactInfo> contactInfo,
-                          LocalDateTime establishedAt, LocalDateTime updatedAt) {
-        return new Club(id, name, category, shortDescription, introduction, clubImageUrl, recruitingStatus,
-                activities, recruitment, contactInfo, establishedAt, updatedAt);
+                          LocalDateTime establishedAt) {
+        return new Club(name, category, shortDescription, introduction, clubImageUrl, recruitingStatus,
+                activities, recruitment, contactInfo, establishedAt);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/domain/Club.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Club.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.List;
 @Table(name = "club")
 @Schema(description = "동아리 엔티티")
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Club {
 

--- a/club-service/src/main/java/club/gach_dong/domain/Club.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Club.java
@@ -1,66 +1,93 @@
 package club.gach_dong.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
+import java.util.List;
 
-
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@EqualsAndHashCode
+@Entity
+@Table(name = "club")
+@Schema(description = "동아리 엔티티")
 @Getter
-@Entity(name = "club")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Club {
 
     @Id
     @Column(name = "club_id", length = 36, columnDefinition = "CHAR(36)")
+    @Schema(description = "동아리 ID", example = "123e4567-e89b-12d3-a456-426614174000")
     private String id;
 
     @Column(name = "club_name", length = 26, columnDefinition = "CHAR(26)")
+    @Schema(description = "동아리 이름", example = "GDG Gachon")
     private String name;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "club_category", nullable = false)
+    @Schema(description = "동아리 카테고리", example = "IT")
     private ClubCategory category;
 
     @Column(name = "club_short_description", nullable = false)
+    @Schema(description = "동아리 한줄 설명", example = "Google 기술을 연구하는 동아리")
     private String shortDescription;
 
-    @Column(name = "club_description", nullable = false)
-    private String description;
+    @Column(name = "club_introduction", columnDefinition = "TEXT")
+    @Schema(description = "동아리 소개 (HTML 또는 Markdown)", example = "<h1>GDG Gachon</h1><p>Google 기술을 연구하는 동아리...</p>")
+    private String introduction;
 
     @Column(name = "club_image_url")
+    @Schema(description = "동아리 이미지 URL", example = "https://example.com/image.png")
     private String clubImageUrl;
 
     @Column(name = "recruiting_status")
+    @Schema(description = "모집 상태", example = "true")
     private boolean recruitingStatus;
 
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Schema(description = "동아리 활동 목록")
+    private List<Activity> activities;
+
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Schema(description = "동아리 모집 정보")
+    private List<Recruitment> recruitment;
+
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Schema(description = "동아리 연락처 정보")
+    private List<ContactInfo> contactInfo;
+
     @Column(name = "club_established_at")
+    @Schema(description = "동아리 설립 날짜", example = "2020-03-15T10:15:30")
     private LocalDateTime establishedAt;
 
     @Column(name = "updated_at")
+    @Schema(description = "마지막 업데이트 날짜", example = "2023-10-24T12:00:00")
     private LocalDateTime updatedAt;
 
-    public static Club create(
-            String name,
-            ClubCategory category,
-            String shortDescription,
-            String description,
-            String clubImageUrl,
-            boolean recruitingStatus
-    ) {
-        return new Club(
-                UUID.randomUUID().toString(),
-                name,
-                category,
-                shortDescription,
-                description,
-                clubImageUrl,
-                recruitingStatus,
-                LocalDateTime.now(),
-                LocalDateTime.now()
-        );
+    private Club(String id, String name, ClubCategory category, String shortDescription, String introduction,
+                 String clubImageUrl, boolean recruitingStatus, List<Activity> activities, List<Recruitment> recruitment,
+                 List<ContactInfo> contactInfo, LocalDateTime establishedAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.shortDescription = shortDescription;
+        this.introduction = introduction;
+        this.clubImageUrl = clubImageUrl;
+        this.recruitingStatus = recruitingStatus;
+        this.activities = activities;
+        this.recruitment = recruitment;
+        this.contactInfo = contactInfo;
+        this.establishedAt = establishedAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static Club of(String id, String name, ClubCategory category, String shortDescription, String introduction,
+                          String clubImageUrl, boolean recruitingStatus, List<Activity> activities,
+                          List<Recruitment> recruitment, List<ContactInfo> contactInfo,
+                          LocalDateTime establishedAt, LocalDateTime updatedAt) {
+        return new Club(id, name, category, shortDescription, introduction, clubImageUrl, recruitingStatus,
+                activities, recruitment, contactInfo, establishedAt, updatedAt);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/domain/Club.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Club.java
@@ -10,6 +10,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -92,11 +93,15 @@ public class Club {
         this.establishedAt = establishedAt;
     }
 
-    public static Club of(String name, ClubCategory category, String shortDescription, String introduction,
-                          String clubImageUrl, boolean recruitingStatus, List<Activity> activities,
-                          List<Recruitment> recruitment, List<ContactInfo> contactInfo,
-                          LocalDateTime establishedAt) {
-        return new Club(name, category, shortDescription, introduction, clubImageUrl, recruitingStatus,
-                activities, recruitment, contactInfo, establishedAt);
+    public static Club of(
+            String name,
+            ClubCategory category,
+            String shortDescription,
+            String introduction,
+            String clubImageUrl,
+            LocalDateTime establishedAt
+    ) {
+        return new Club(name, category, shortDescription, introduction, clubImageUrl, false,
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), establishedAt);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/domain/ContactInfo.java
+++ b/club-service/src/main/java/club/gach_dong/domain/ContactInfo.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "contact_info")
 @Schema(description = "동아리의 연락처 정보를 나타내는 엔티티")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/club-service/src/main/java/club/gach_dong/domain/ContactInfo.java
+++ b/club-service/src/main/java/club/gach_dong/domain/ContactInfo.java
@@ -1,0 +1,40 @@
+package club.gach_dong.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "contact_info")
+@Schema(description = "동아리의 연락처 정보를 나타내는 엔티티")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContactInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "연락처 ID", example = "1")
+    private Long id;
+
+    @Column(name = "contact_method", nullable = false)
+    @Schema(description = "연락 수단 (예: gmail, instagram)", example = "gmail")
+    private String contactMethod;
+
+    @Column(name = "contact_value", nullable = false)
+    @Schema(description = "연락처 정보 (예: test@gmail.com, @test)", example = "test@gmail.com")
+    private String contactValue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    private ContactInfo(String contactMethod, String contactValue, Club club) {
+        this.contactMethod = contactMethod;
+        this.contactValue = contactValue;
+    }
+
+    public static ContactInfo of(String contactMethod, String contactValue, Club club) {
+        return new ContactInfo(contactMethod, contactValue, club);
+    }
+}

--- a/club-service/src/main/java/club/gach_dong/domain/Recruitment.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Recruitment.java
@@ -1,0 +1,48 @@
+package club.gach_dong.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "recruitment")
+@Schema(description = "동아리 모집 정보를 나타내는 엔티티")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recruitment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "모집 ID", example = "1")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    @Schema(description = "모집 제목", example = "GDSC Gachon 2024 멤버 모집")
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Column(name = "start_date", nullable = false)
+    @Schema(description = "모집 시작일", example = "2024-03-01")
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    @Schema(description = "모집 종료일", example = "2024-03-15")
+    private LocalDate endDate;
+
+
+    private Recruitment(String title, LocalDate startDate, LocalDate endDate, Club club) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.club = club;
+    }
+
+    public static Recruitment of(String title, LocalDate startDate, LocalDate endDate, Club club) {
+        return new Recruitment(title, startDate, endDate, club);
+    }
+}

--- a/club-service/src/main/java/club/gach_dong/dto/request/CreateClubRequest.java
+++ b/club-service/src/main/java/club/gach_dong/dto/request/CreateClubRequest.java
@@ -1,0 +1,33 @@
+package club.gach_dong.dto.request;
+
+import club.gach_dong.domain.ClubCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record CreateClubRequest(
+
+        @Schema(description = "동아리 이름", example = "가츠동")
+        @NotBlank
+        String name,
+
+        @Schema(description = "동아리 카테고리", example = "SPORTS")
+        @NotNull
+        ClubCategory category,
+
+        @Schema(description = "동아리 한줄 설명", example = "가츠동은 최고의 동아리입니다.")
+        @NotBlank
+        String shortDescription,
+
+        @Schema(description = "동아리 소개", example = "<h1>가츠동</h1> <p>최고의 동아리입니다</p>")
+        String introduction,
+
+        @Schema(description = "동아리 이미지 URL", example = "http://example.com/image.png")
+        String clubImageUrl,
+
+        @Schema(description = "동아리 설립일", example = "2023-01-01T00:00:00")
+        LocalDateTime establishedAt
+) {
+}

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubActivityResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubActivityResponse.java
@@ -1,0 +1,25 @@
+package club.gach_dong.dto.response;
+
+import club.gach_dong.domain.Activity;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record ClubActivityResponse (
+        @Schema(description = "활동 제목", example = "2024년 봄 캠프")
+        String title,
+
+        @Schema(description = "활동 날짜", example = "2024-04-12")
+        LocalDate date,
+
+        @Schema(description = "활동 설명", example = "봄 캠프에서 다양한 활동을 했습니다.")
+        String description
+) {
+    public static ClubActivityResponse from(Activity activity) {
+        return new ClubActivityResponse(
+                activity.getTitle(),
+                activity.getDate(),
+                activity.getDescription()
+        );
+    }
+}

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubContactInfoResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubContactInfoResponse.java
@@ -1,0 +1,22 @@
+package club.gach_dong.dto.response;
+
+import club.gach_dong.domain.Activity;
+import club.gach_dong.domain.ContactInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record ClubContactInfoResponse(
+        @Schema(description = "연락 수단 (예: gmail, phone)", example = "gmail")
+        String contactMethod,
+
+        @Schema(description = "연락처 정보", example = "gachdong@gmail.com")
+        String contactValue
+) {
+    public static ClubContactInfoResponse from(ContactInfo contactInfo) {
+        return new ClubContactInfoResponse(
+                contactInfo.getContactMethod(),
+                contactInfo.getContactValue()
+        );
+    }
+}

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubContactInfoResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubContactInfoResponse.java
@@ -1,10 +1,7 @@
 package club.gach_dong.dto.response;
 
-import club.gach_dong.domain.Activity;
 import club.gach_dong.domain.ContactInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.time.LocalDate;
 
 public record ClubContactInfoResponse(
         @Schema(description = "연락 수단 (예: gmail, phone)", example = "gmail")

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubResponse.java
@@ -23,7 +23,7 @@ public record ClubResponse(
         boolean recruitingStatus,
 
         @Schema(description = "동아리 설명", example = "가츠동은 다양한 활동을 하는 동아리입니다.")
-        String description,
+        String introduction,
 
         @Schema(description = "설립일", example = "2023-01-01T00:00:00")
         LocalDateTime establishedAt,
@@ -31,6 +31,7 @@ public record ClubResponse(
         @Schema(description = "업데이트일", example = "2023-01-01T00:00:00")
         LocalDateTime updatedAt
 ) {
+
     public static ClubResponse from(Club club) {
         return new ClubResponse(
                 club.getName(),
@@ -38,9 +39,10 @@ public record ClubResponse(
                 club.getShortDescription(),
                 club.getClubImageUrl(),
                 club.isRecruitingStatus(),
-                club.getDescription(),
+                club.getIntroduction(),
                 club.getEstablishedAt(),
                 club.getUpdatedAt()
         );
     }
 }
+

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubResponse.java
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record ClubResponse(
+        @Schema(description = "동아리 ID", example = "ansier-enicsei-1233na-bndknar")
+        String clubId,
+
         @Schema(description = "동아리 이름", example = "가츠동")
         String clubName,
 
@@ -34,6 +37,7 @@ public record ClubResponse(
 
     public static ClubResponse from(Club club) {
         return new ClubResponse(
+                club.getId(),
                 club.getName(),
                 club.getCategory(),
                 club.getShortDescription(),

--- a/club-service/src/main/java/club/gach_dong/repository/ClubRepository.java
+++ b/club-service/src/main/java/club/gach_dong/repository/ClubRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface ClubRepository extends JpaRepository<Club, String> {
     List<Club> findAll();
 
-    Optional<Club> findByName(String name);
+    Optional<Club> findById(String id);
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubService.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubService.java
@@ -1,5 +1,6 @@
 package club.gach_dong.service;
 
+import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface ClubService {
     List<ClubSummaryResponse> getAllClubs();
     ClubResponse getClub(String clubId);
+    ClubResponse createClub(CreateClubRequest createClubRequest);
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubService.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubService.java
@@ -2,6 +2,7 @@ package club.gach_dong.service;
 
 import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ClubActivityResponse;
+import club.gach_dong.dto.response.ClubContactInfoResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 
@@ -12,4 +13,5 @@ public interface ClubService {
     ClubResponse getClub(String clubId);
     ClubResponse createClub(CreateClubRequest createClubRequest);
     List<ClubActivityResponse> getClubActivities(String clubId);
+    List<ClubContactInfoResponse> getClubContactInfo(String clubId);
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubService.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubService.java
@@ -1,6 +1,7 @@
 package club.gach_dong.service;
 
 import club.gach_dong.dto.request.CreateClubRequest;
+import club.gach_dong.dto.response.ClubActivityResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 
@@ -10,4 +11,5 @@ public interface ClubService {
     List<ClubSummaryResponse> getAllClubs();
     ClubResponse getClub(String clubId);
     ClubResponse createClub(CreateClubRequest createClubRequest);
+    List<ClubActivityResponse> getClubActivities(String clubId);
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -2,8 +2,10 @@ package club.gach_dong.service;
 
 import club.gach_dong.domain.Activity;
 import club.gach_dong.domain.Club;
+import club.gach_dong.domain.ContactInfo;
 import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ClubActivityResponse;
+import club.gach_dong.dto.response.ClubContactInfoResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.repository.ClubRepository;
@@ -67,7 +69,19 @@ public class ClubServiceImpl implements ClubService {
         List<Activity> activities = club.getActivities();
 
         return activities.stream()
-                .map(ClubActivityResponse::from)  // 각 Activity 엔티티를 DTO로 변환
+                .map(ClubActivityResponse::from)
+                .toList();
+    }
+
+    @Override
+    public List<ClubContactInfoResponse> getClubContactInfo(String clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new NotFoundException("Club not found"));
+
+        List<ContactInfo> contactInfos = club.getContactInfo();
+
+        return contactInfos.stream()
+                .map(ClubContactInfoResponse::from)
                 .toList();
     }
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -1,13 +1,15 @@
 package club.gach_dong.service;
 
+import club.gach_dong.domain.Club;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,15 +19,20 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public List<ClubSummaryResponse> getAllClubs() {
-        return clubRepository.findAll().stream()
-                .map(ClubSummaryResponse::from)
-                .collect(Collectors.toList());
+        List<ClubSummaryResponse> clubList = new ArrayList<>();
+
+        for (Club club : clubRepository.findAll()) {
+            ClubSummaryResponse from = ClubSummaryResponse.from(club);
+            clubList.add(from);
+        }
+
+        return clubList;
     }
 
     @Override
-    public ClubResponse getClub(String name) {
-        return clubRepository.findByName(name)
+    public ClubResponse getClub(String id) {
+        return clubRepository.findById(id)
                 .map(ClubResponse::from)
-                .orElseThrow(() -> new RuntimeException("Club not found"));
+                .orElseThrow(() -> new NotFoundException("Club not found"));
     }
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -36,8 +36,8 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public ClubResponse getClub(String id) {
-        return clubRepository.findById(id)
+    public ClubResponse getClub(String clubIId) {
+        return clubRepository.findById(clubIId)
                 .map(ClubResponse::from)
                 .orElseThrow(() -> new NotFoundException("Club not found"));
     }
@@ -50,10 +50,6 @@ public class ClubServiceImpl implements ClubService {
                 createClubRequest.shortDescription(),
                 createClubRequest.introduction(),
                 createClubRequest.clubImageUrl(),
-                false,
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
                 createClubRequest.establishedAt()
         );
         Club savedClub = clubRepository.save(club);

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -1,6 +1,7 @@
 package club.gach_dong.service;
 
 import club.gach_dong.domain.Club;
+import club.gach_dong.dto.request.CreateClubRequest;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.repository.ClubRepository;
@@ -34,5 +35,23 @@ public class ClubServiceImpl implements ClubService {
         return clubRepository.findById(id)
                 .map(ClubResponse::from)
                 .orElseThrow(() -> new NotFoundException("Club not found"));
+    }
+
+    @Override
+    public ClubResponse createClub(CreateClubRequest createClubRequest) {
+        Club club = Club.of(
+                createClubRequest.name(),
+                createClubRequest.category(),
+                createClubRequest.shortDescription(),
+                createClubRequest.introduction(),
+                createClubRequest.clubImageUrl(),
+                false,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                createClubRequest.establishedAt()
+        );
+        Club savedClub = clubRepository.save(club);
+        return ClubResponse.from(savedClub);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -1,12 +1,15 @@
 package club.gach_dong.service;
 
+import club.gach_dong.domain.Activity;
 import club.gach_dong.domain.Club;
 import club.gach_dong.dto.request.CreateClubRequest;
+import club.gach_dong.dto.response.ClubActivityResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.repository.ClubRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
 
 import java.util.ArrayList;
@@ -53,5 +56,18 @@ public class ClubServiceImpl implements ClubService {
         );
         Club savedClub = clubRepository.save(club);
         return ClubResponse.from(savedClub);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ClubActivityResponse> getClubActivities(String clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new NotFoundException("Club not found"));
+
+        List<Activity> activities = club.getActivities();
+
+        return activities.stream()
+                .map(ClubActivityResponse::from)  // 각 Activity 엔티티를 DTO로 변환
+                .toList();
     }
 }


### PR DESCRIPTION
## 1. 관련 이슈
#6 
<!-- 연관된 이슈를 링크해주세요. -->
1. 조회 API에 아직 특정 값들에 대한 필터링 기능은 추가하지 않았습니다. 아마, 다음 스프린트 때 함께 작업이 진행될 예정입니다.
2. 전체적인 예외처리가 반영되지 않았습니다. 공통 예외처리 및 에러코드 작업 진행 후 리팩토링될 예정입니다.
3. 추가적인 이슈나 공유 사항이 있을 경우에 공유드리겠습니다.

## 2. 구현한 내용 또는 수정한 내용
Club 도메인의 Entity 설계 및 구현

- Club
- Activity 
- ContactInfo 
- Recruitment

동아리 탐색 기능 구현
- getClub -> 특정 동아리 조회용 API
- getClubs -> 전체 동아리 리스트 조회용 API
- getClubActivities -> 특정 동아리 활동 내역 조회용 API 
- getClubContactInfo -> 특정 동아리 연락처 정보 조회용 API
- createClub -> 동아리 생성 API
<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 혹은 gif 등을 활용해 자유롭게 보여주세요. -->

## 3. TODO
- [x] 동아리 조회
- [x] 동아리 활동내역 조회
- [x] 동아리 연락처 정보 조회
- [x] 동아리 생성
 
## 4. 배포 전 Checklist
<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->