### PR TITLE
[FEAT] 지원서 양식 및 지원 관련 기능 구현

### DIFF
--- a/application-service/.gitignore
+++ b/application-service/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+**/src/main/resources/*.json

--- a/application-service/build.gradle
+++ b/application-service/build.gradle
@@ -26,7 +26,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -39,8 +38,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	//  Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
 	//GCP S3
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.8.RELEASE'

--- a/application-service/build.gradle
+++ b/application-service/build.gradle
@@ -41,6 +41,11 @@ dependencies {
 
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	//GCP S3
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.8.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.8.RELEASE'
+
 }
 
 //tasks.named('test') {

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -31,7 +31,7 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.")
     @GetMapping("/application/list")
-    ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getFormInfoUser(HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.")
     @PostMapping("/application/admin/form/create")

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -44,9 +44,9 @@ public interface ApplicationApiSpecification {
                                                                              @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "일반 추첨 신청에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClub toApplyClub,
                                                                              HttpServletRequest httpServletRequest);
 
-    @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 수정합니다.")
-    @PutMapping("/application/admin/form/create")
-    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(@Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
+    @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.")
+    @PutMapping("/application/admin/form/{form_id}")
+    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(@PathVariable("form_id") Long formId, @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원 API", description = "동아리에 지원을 수정합니다.")
     @PutMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -13,8 +13,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 @Tag(name = "지원 API", description = "동아리 지원 관련 API")
@@ -25,11 +23,11 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "관리자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.")
     @GetMapping("/admin/form/{formId}")
-    ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long drawId, HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.")
     @GetMapping("/form/{formId}")
-    ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(@PathVariable("formId") Long drawId, HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.")
     @GetMapping("/application/list")

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -38,21 +38,23 @@ public interface ApplicationApiSpecification {
     ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(@Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원 API", description = "동아리에 지원합니다.")
-    @PostMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(@PathVariable("apply_id") Long applyId,
-                                                                             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> files,
-                                                                             @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
-                                                                             HttpServletRequest httpServletRequest);
+    @PostMapping(value = "/{apply_id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(
+            @PathVariable("apply_id") Long applyId,
+            @RequestPart(value = "files", required = false) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> files,
+            @RequestPart(value = "toApplyClub") @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+            HttpServletRequest httpServletRequest
+    );
 
     @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.")
     @PutMapping("/application/admin/form/{form_id}")
     ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(@PathVariable("form_id") Long formId, @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
 
-    @Operation(summary = "동아리 지원 API", description = "동아리에 지원을 수정합니다.")
+    @Operation(summary = "동아리 지원 수정 API", description = "동아리에 지원을 수정합니다.")
     @PutMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(@PathVariable("apply_id") Long applyId,
                                                                              @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> certificateDocs,
-                                                                             @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+                                                                             @RequestPart(value = "toApplyClub", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
                                                                              HttpServletRequest httpServletRequest);
 
     @Operation(summary = "지원 양식 삭제 API", description = "지원서 양식 ID를 이용해 양식을 삭제합니다.")

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -40,8 +40,8 @@ public interface ApplicationApiSpecification {
     @Operation(summary = "동아리 지원 API", description = "동아리에 지원합니다.")
     @PostMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(@PathVariable("apply_id") Long applyId,
-                                                                             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 인증서 문서 리스트") List<MultipartFile> certificateDocs,
-                                                                             @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "일반 추첨 신청에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClub toApplyClub,
+                                                                             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> files,
+                                                                             @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
                                                                              HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.")
@@ -51,13 +51,13 @@ public interface ApplicationApiSpecification {
     @Operation(summary = "동아리 지원 API", description = "동아리에 지원을 수정합니다.")
     @PutMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(@PathVariable("apply_id") Long applyId,
-                                                                             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 인증서 문서 리스트") List<MultipartFile> certificateDocs,
-                                                                             @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "일반 추첨 신청에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClub toApplyClub,
+                                                                             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> certificateDocs,
+                                                                             @RequestPart(value = "applyDrawRequestDTO", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
                                                                              HttpServletRequest httpServletRequest);
 
     @Operation(summary = "지원 양식 삭제 API", description = "지원서 양식 ID를 이용해 양식을 삭제합니다.")
     @DeleteMapping("/admin/form/{formId}")
-    ResForm<?> deleteForm(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
+    ResForm<?> deleteApplicationForm(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자 지원 취소 API", description = "지원 ID를 이용해 지원을 취소합니다.")
     @DeleteMapping("/apply/{applyId}")

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,7 +16,6 @@ import java.util.List;
 
 @Tag(name = "지원 API", description = "동아리 지원 관련 API")
 @RestController
-@Validated
 @RequestMapping("v1/application")
 public interface ApplicationApiSpecification {
 

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -52,10 +52,11 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "동아리 지원 수정 API", description = "동아리에 지원을 수정합니다.")
     @PutMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(@PathVariable("apply_id") Long applyId,
-                                                                             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> certificateDocs,
-                                                                             @RequestPart(value = "toApplyClub", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
-                                                                             HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(
+            @PathVariable("apply_id") Long applyId,
+            @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> certificateDocs,
+            @RequestPart(value = "toApplyClub", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "지원 양식 삭제 API", description = "지원서 양식 ID를 이용해 양식을 삭제합니다.")
     @DeleteMapping("/admin/form/{formId}")

--- a/application-service/src/main/java/club/gach_dong/config/OctetStreamReadMsgConverter.java
+++ b/application-service/src/main/java/club/gach_dong/config/OctetStreamReadMsgConverter.java
@@ -1,0 +1,32 @@
+package club.gach_dong.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -46,8 +46,7 @@ public class ApplicationController implements ApplicationApiSpecification {
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
         ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(applyId, files, toApplyClub, httpServletRequest);
-
-        return ResForm.onSuccess(InSuccess._OK, toCreateApplicationDTO);
+        return ResForm.onSuccess(InSuccess.APPLICATION_SUCCESS, toCreateApplicationDTO);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -4,16 +4,21 @@ import club.gach_dong.api.ApplicationApiSpecification;
 import club.gach_dong.dto.request.ApplicationRequestDTO;
 import club.gach_dong.dto.response.ApplicationResponseDTO;
 import club.gach_dong.response.ResForm;
+import club.gach_dong.response.status.InSuccess;
+import club.gach_dong.service.ApplicationService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class ApplicationController implements ApplicationApiSpecification {
+
+    public final ApplicationService applicationService;
+
     @Override
     public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long drawId, HttpServletRequest httpServletRequest) {
         return null;
@@ -30,8 +35,9 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        return null;
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO, HttpServletRequest httpServletRequest) {
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(createApplicationFormDTO, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CREATED, toCreateApplicationFormDTO);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -48,8 +48,9 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        return null;
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 =  applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -68,7 +68,8 @@ public class ApplicationController implements ApplicationApiSpecification {
 
     @Override
     public ResForm<?> deleteApplication(Long applyId, HttpServletRequest httpServletRequest) {
-        return null;
+        applicationService.deleteApplication(applyId, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_DELETED, null);
     }
 
     ;

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -57,7 +57,8 @@ public class ApplicationController implements ApplicationApiSpecification {
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
-        return null;
+        ApplicationResponseDTO.ToCreateApplicationDTO toChangeApplicationDTO = applicationService.changeApplication(applyId, certificateDocs, toApplyClub, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_CHANGED, toChangeApplicationDTO);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -59,8 +59,9 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<?> deleteForm(Long formId, HttpServletRequest httpServletRequest) {
-        return null;
+    public ResForm<?> deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
+        applicationService.deleteApplicationForm(formId, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_DELETED, null);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -43,8 +43,10 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClub toApplyClub, HttpServletRequest httpServletRequest) {
-        return null;
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
+        ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(applyId, files, toApplyClub, httpServletRequest);
+
+        return ResForm.onSuccess(InSuccess._OK, toCreateApplicationDTO);
     }
 
     @Override
@@ -54,7 +56,7 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClub toApplyClub, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
         return null;
     }
 

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -33,7 +33,8 @@ public class ApplicationController implements ApplicationApiSpecification {
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest) {
-        return null;
+        ApplicationResponseDTO.ToGetApplicationHistoryListDTO toGetApplicationHistoryListDTO = applicationService.getApplicationHistoryList(httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetApplicationHistoryListDTO);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -51,7 +51,7 @@ public class ApplicationController implements ApplicationApiSpecification {
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 =  applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, httpServletRequest);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
     }
 

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -32,7 +32,7 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getFormInfoUser(HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest) {
         return null;
     }
 

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -20,13 +20,15 @@ public class ApplicationController implements ApplicationApiSpecification {
     public final ApplicationService applicationService;
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long drawId, HttpServletRequest httpServletRequest) {
-        return null;
+    public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest) {
+        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_ADMIN_INFO, toGetFormInfoAdminDTO);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long drawId, HttpServletRequest httpServletRequest) {
-        return null;
+    public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long formId, HttpServletRequest httpServletRequest) {
+        ApplicationResponseDTO.ToGetFormInfoUserDTO toGetFormInfoUserDTO = applicationService.getFormInfoUser(formId, httpServletRequest);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetFormInfoUserDTO);
     }
 
     @Override

--- a/application-service/src/main/java/club/gach_dong/domain/Application.java
+++ b/application-service/src/main/java/club/gach_dong/domain/Application.java
@@ -16,22 +16,22 @@ public class Application {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id" ,nullable = false)
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "apply_id" ,nullable = false)
+    @Column(name = "apply_id", nullable = false)
     private Long applyId;
 
-    @Column(name = "application_form_id" ,nullable = false)
+    @Column(name = "application_form_id", nullable = false)
     private Long applicationFormId;
 
-    @Column(name = "application_body" ,nullable = false, length = 30000)
+    @Column(name = "application_body", nullable = false, length = 30000)
     private String applicationBody;
 
-    @Column(name = "application_status" ,nullable = false, length = 30)
+    @Column(name = "application_status", nullable = false, length = 30)
     private String applicationStatus;
 
-    @Column(name = "club_name" ,nullable = false, length = 80)
+    @Column(name = "club_name", nullable = false, length = 80)
     private String clubName;
 
 }

--- a/application-service/src/main/java/club/gach_dong/domain/Application.java
+++ b/application-service/src/main/java/club/gach_dong/domain/Application.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EqualsAndHashCode
 @Getter
 @Builder
 @Entity(name = "application")

--- a/application-service/src/main/java/club/gach_dong/domain/Application.java
+++ b/application-service/src/main/java/club/gach_dong/domain/Application.java
@@ -7,6 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter
+@Builder
 @Entity(name = "application")
 public class Application {
 
@@ -24,7 +25,6 @@ public class Application {
     @Column(name = "application_form_id" ,nullable = false)
     private Long applicationFormId;
 
-
     @Column(name = "application_body" ,nullable = false, length = 30000)
     private String applicationBody;
 
@@ -33,6 +33,5 @@ public class Application {
 
     @Column(name = "club_name" ,nullable = false, length = 80)
     private String clubName;
-
 
 }

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationDocs.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationDocs.java
@@ -15,12 +15,12 @@ public class ApplicationDocs {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "application_id" ,nullable = false)
+    @Column(name = "application_id", nullable = false)
     private Long applicationId;
 
-    @Column(name = "file_url" ,nullable = false, length = 255)
+    @Column(name = "file_url", nullable = false, length = 255)
     private String fileUrl;
 
-    @Column(name = "file_name" ,nullable = false, length = 30)
+    @Column(name = "file_name", nullable = false, length = 30)
     private String fileName;
 }

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationDocs.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationDocs.java
@@ -1,0 +1,26 @@
+package club.gach_dong.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+@Getter
+@Builder
+@Entity(name = "applicationDocs")
+public class ApplicationDocs {
+    @Id
+    @Column(name = "application_docs_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "application_id" ,nullable = false)
+    private Long applicationId;
+
+    @Column(name = "file_url" ,nullable = false, length = 255)
+    private String fileUrl;
+
+    @Column(name = "file_name" ,nullable = false, length = 30)
+    private String fileName;
+}

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationDocs.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationDocs.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EqualsAndHashCode
 @Getter
 @Builder
 @Entity(name = "applicationDocs")

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
@@ -1,0 +1,30 @@
+package club.gach_dong.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+@Getter
+@Builder
+@Entity(name = "applicationForm")
+public class ApplicationForm {
+    @Id
+    @Column(name = "application_form_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "apply_id" ,nullable = false)
+    private Long applyId;
+
+    @Column(name = "application_form_status", nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private ApplicationFormStatus applicationFormStatus;
+
+    @Column(name = "form_name" ,nullable = false, length = 50)
+    private String formName;
+
+    @Column(name = "application_form_body" ,nullable = false, length = 2000)
+    private String body;
+}

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
@@ -5,7 +5,6 @@ import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@EqualsAndHashCode
 @Getter
 @Builder
 @Entity(name = "applicationForm")

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
@@ -15,16 +15,16 @@ public class ApplicationForm {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "apply_id" ,nullable = false)
+    @Column(name = "apply_id", nullable = false)
     private Long applyId;
 
     @Column(name = "application_form_status", nullable = false)
     @Enumerated(value = EnumType.STRING)
     private ApplicationFormStatus applicationFormStatus;
 
-    @Column(name = "form_name" ,nullable = false, length = 50)
+    @Column(name = "form_name", nullable = false, length = 50)
     private String formName;
 
-    @Column(name = "application_form_body" ,nullable = false, length = 2000)
+    @Column(name = "application_form_body", nullable = false, length = 2000)
     private String body;
 }

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationFormStatus.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationFormStatus.java
@@ -1,9 +1,7 @@
 package club.gach_dong.domain;
 
 public enum ApplicationFormStatus {
-    SUBMITTED,
     TEMPORARY_SAVED,
-    SUBMITTED_CHANGEABLE,
-    FINISHED
-
+    SAVED,
+    IN_USE
 }

--- a/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
@@ -27,9 +27,6 @@ public class ApplicationRequestDTO {
 
     @Getter
     public static class ToApplyClubDTO{
-        @NotNull(message = "동아리 모집 Id가 누락되었습니다.")
-        private Long applyId;
-
         @NotNull(message = "지원서 Id가 누락되었습니다.")
         private Long applicationFormId;
 

--- a/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
@@ -26,7 +26,7 @@ public class ApplicationRequestDTO {
     }
 
     @Getter
-    public static class ToApplyClub{
+    public static class ToApplyClubDTO{
         @NotNull(message = "동아리 모집 Id가 누락되었습니다.")
         private Long applyId;
 
@@ -35,5 +35,13 @@ public class ApplicationRequestDTO {
 
         @Size(max = 30000, message = "지원서 답변이 너무 큽니다.")
         private String formBody;
+
+        @NotNull(message = "지원 상태가 누락되었습니다.")
+        @Pattern(regexp = "TEMPORARY_SAVED|SAVED|SAVED_CHANGEABLE", message = "지원 상태는 TEMPORARY_SAVED 또는 SAVED, SAVED_CHANGEABLE 이어야 합니다.")
+        private String status;
+        
+        @NotNull(message = "동아리 이름이 누락되었습니다.")
+        @Size(max = 80, message = "동이리 이름이 너무 큽니다.")
+        private String clubName;
     }
 }

--- a/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
@@ -9,11 +9,11 @@ public class ApplicationRequestDTO {
 
     @Getter
     public static class ToCreateApplicationFormDTO{
-        @NotNull(message = "ClubId가 누락되었습니다.")
-        private Long clubId;
+        @NotNull(message = "ApplyId가 누락되었습니다.")
+        private Long applyId;
 
-        @NotNull(message = "지원서 상태가 누락되었습니다.")
-        @Pattern(regexp = "TEMP|NOTUSE", message = "지원서 상태는 TEMP 또는 NOTUSE 이어야 합니다.")
+        @NotNull(message = "지원 양식 상태가 누락되었습니다.")
+        @Pattern(regexp = "TEMPORARY_SAVED|SAVED", message = "지원 양식 상태는 TEMPORARY_SAVED 또는 SAVED 이어야 합니다.")
         private String status;
 
         @NotNull(message = "지원서 이름이 누락되었습니다.")

--- a/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class ApplicationRequestDTO {
 
     @Getter
-    public static class ToCreateApplicationFormDTO{
+    public static class ToCreateApplicationFormDTO {
         @NotNull(message = "ApplyId가 누락되었습니다.")
         private Long applyId;
 
@@ -26,7 +26,7 @@ public class ApplicationRequestDTO {
     }
 
     @Getter
-    public static class ToApplyClubDTO{
+    public static class ToApplyClubDTO {
         @NotNull(message = "지원서 Id가 누락되었습니다.")
         private Long applicationFormId;
 
@@ -36,7 +36,7 @@ public class ApplicationRequestDTO {
         @NotNull(message = "지원 상태가 누락되었습니다.")
         @Pattern(regexp = "TEMPORARY_SAVED|SAVED|SAVED_CHANGEABLE", message = "지원 상태는 TEMPORARY_SAVED 또는 SAVED, SAVED_CHANGEABLE 이어야 합니다.")
         private String status;
-        
+
         @NotNull(message = "동아리 이름이 누락되었습니다.")
         @Size(max = 80, message = "동이리 이름이 너무 큽니다.")
         private String clubName;

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
@@ -64,9 +64,25 @@ public class ObjectStorageService {
         return url;
     }
 
-    public void deleteObject(String directory, String objectKey) {
+    /**
+     * @param url: 삭제할 객체 정보, 무조건 삭제할 객체가 '버킷의 root dir/subdir' 내에 있어야 함
+     * @return
+     */
+    
+    public void deleteObject(String url) {
 
         String bucketName = objectStorageServiceConfig.getBucketName();
+
+        String[] extractSegments = extractSegments(url);
+
+        String directory = extractSegments[0];
+        String objectKey = extractSegments[1];
+
+        if(directory==null || objectKey==null){
+            logger.warn("Url format is Wrong. objectKey: {}, bucketName: {} have to be not null.", objectKey, bucketName);
+            //throw new CustomException(ErrorStatus.FILE_DELETE_FAILED_CRITICAL);
+            return;
+        }
 
         BlobId blobId = BlobId.of(bucketName, directory + "/" + objectKey);
         Blob blob = storage.get(blobId);
@@ -91,6 +107,14 @@ public class ObjectStorageService {
             logger.error("Failed to delete object: {}", ex.getMessage(), ex);
             //throw new CustomException(ErrorStatus.FILE_DELETE_FAILED_CRITICAL);
         }
+    }
+
+    public static String[] extractSegments(String url) {
+        String[] parts = url.split("/");
+        if (parts.length >= 5) {
+            return new String[]{parts[4], parts[5]};
+        }
+        return null;
     }
 
 }

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
@@ -1,0 +1,68 @@
+package club.gach_dong.gcp;
+
+import club.gach_dong.exception.CustomException;
+import club.gach_dong.response.status.ErrorStatus;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ObjectStorageService {
+
+    private final ObjectStorageServiceConfig objectStorageServiceConfig;
+    private final Storage storage;
+
+    private static final Logger logger = LogManager.getLogger(ObjectStorageService.class);
+
+
+    /**
+     * @param directory: ObjectStorageConfig 및 application.yml에 정의되어있는 object storage 내 디렉토리
+     * @param objectKey: 업로드할 파일의 이름
+     * @param file:      업로드할 파일 객체
+     * @return
+     */
+
+    public String uploadObject(String directory, String objectKey, MultipartFile file) {
+
+        String fileName = file.getOriginalFilename();
+
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            throw new CustomException(ErrorStatus._BAD_REQUEST);
+        }
+
+        BlobId blobId = BlobId.of(objectStorageServiceConfig.getBucketName(), directory + "/" + objectKey);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
+                .setContentType(contentType)
+                .build();
+        try (WriteChannel writer = storage.writer(blobInfo)) {
+            byte[] imageData = file.getBytes();
+            writer.write(ByteBuffer.wrap(imageData));
+        } catch (Exception ex) {
+            logger.error("Failed to upload object: {}", ex.getMessage(), ex);
+            throw new CustomException(ErrorStatus._BAD_REQUEST);
+        }
+
+        // Construct the URL to access the uploaded object
+        String url = "https://storage.googleapis.com/" + objectStorageServiceConfig.getBucketName() + "/" + directory + "/" + objectKey;
+        return url;
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
@@ -2,23 +2,16 @@ package club.gach_dong.gcp;
 
 import club.gach_dong.exception.CustomException;
 import club.gach_dong.response.status.ErrorStatus;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.*;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
@@ -68,7 +68,7 @@ public class ObjectStorageService {
      * @param url: 삭제할 객체 정보, 무조건 삭제할 객체가 '버킷의 root dir/subdir' 내에 있어야 함
      * @return
      */
-    
+
     public void deleteObject(String url) {
 
         String bucketName = objectStorageServiceConfig.getBucketName();
@@ -78,7 +78,7 @@ public class ObjectStorageService {
         String directory = extractSegments[0];
         String objectKey = extractSegments[1];
 
-        if(directory==null || objectKey==null){
+        if (directory == null || objectKey == null) {
             logger.warn("Url format is Wrong. objectKey: {}, bucketName: {} have to be not null.", objectKey, bucketName);
             //throw new CustomException(ErrorStatus.FILE_DELETE_FAILED_CRITICAL);
             return;

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageServiceConfig.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageServiceConfig.java
@@ -1,0 +1,39 @@
+package club.gach_dong.gcp;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Getter
+@Configuration
+public class ObjectStorageServiceConfig {
+    @Value("${spring.cloud.gcp.storage.bucket}") // application.yml에 써둔 bucket 이름
+    private String bucketName;
+
+    @Value("${spring.cloud.gcp.storage.project-id}")
+    private String projectId;
+
+    @Value("${spring.cloud.gcp.storage.credentials.location}")
+    private String credentials;
+
+    @Value("${spring.cloud.gcp.storage.path.applicationDocs}")
+    private String applicationDocsDir;
+
+    @Bean
+    public Storage storage() throws IOException {
+        ClassPathResource resource = new ClassPathResource(credentials);
+        GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+        return StorageOptions.newBuilder()
+                .setCredentials(credentials)
+                .setProjectId(projectId)
+                .build()
+                .getService();
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
@@ -5,7 +5,12 @@ import club.gach_dong.domain.ApplicationForm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ApplicationDocsRepository extends JpaRepository<ApplicationDocs, Long> {
 
+    List<ApplicationDocs> findAllByApplicationId(Long applicationId);
+
+    void deleteAllByApplicationId(Long applicationId);
 }

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
@@ -1,0 +1,11 @@
+package club.gach_dong.repository;
+
+import club.gach_dong.domain.ApplicationDocs;
+import club.gach_dong.domain.ApplicationForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplicationDocsRepository extends JpaRepository<ApplicationDocs, Long> {
+
+}

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
@@ -3,6 +3,9 @@ package club.gach_dong.repository;
 import club.gach_dong.domain.ApplicationDocs;
 import club.gach_dong.domain.ApplicationForm;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,5 +15,5 @@ public interface ApplicationDocsRepository extends JpaRepository<ApplicationDocs
 
     List<ApplicationDocs> findAllByApplicationId(Long applicationId);
 
-    void deleteAllByApplicationId(Long applicationId);
+    void deleteByApplicationId(Long applicationId);
 }

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationDocsRepository.java
@@ -1,11 +1,7 @@
 package club.gach_dong.repository;
 
 import club.gach_dong.domain.ApplicationDocs;
-import club.gach_dong.domain.ApplicationForm;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationFormRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationFormRepository.java
@@ -1,0 +1,11 @@
+package club.gach_dong.repository;
+
+import club.gach_dong.domain.ApplicationForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplicationFormRepository extends JpaRepository<ApplicationForm, Long> {
+
+
+}

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -1,0 +1,14 @@
+package club.gach_dong.repository;
+
+import club.gach_dong.domain.Application;
+import club.gach_dong.domain.ApplicationForm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+
+    Optional<Application> findByUserIdAndApplyId(Long userId, Long applyId);
+}

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -5,10 +5,13 @@ import club.gach_dong.domain.ApplicationForm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
     Optional<Application> findByUserIdAndApplyId(Long userId, Long applyId);
+
+    List<Application> findAllByUserId(Long userId);
 }

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -1,7 +1,6 @@
 package club.gach_dong.repository;
 
 import club.gach_dong.domain.Application;
-import club.gach_dong.domain.ApplicationForm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/application-service/src/main/java/club/gach_dong/response/ResForm.java
+++ b/application-service/src/main/java/club/gach_dong/response/ResForm.java
@@ -8,12 +8,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"time", "code", "message", "result"})
-public class ResForm <T> {
+public class ResForm<T> {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime time;

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -18,6 +18,18 @@ public enum ErrorStatus {
 
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATIONFORM401", "ApplicationForm이 없습니다."),
     APPLICATION_FORM_IN_USE(HttpStatus.CONFLICT, "APPLICATIONFORM402", "이미 사용중인 지원서 양식입니다."),
+
+    APPLICATION_DUPLICATED(HttpStatus.CONFLICT, "APPLICATION401", "신청이 중복되었습니다."),
+
+
+
+    //  파일 업로드 관련
+    FILE_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "FILE4001", "업로드한 문서의 이름이 없습니다."),
+    FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FILE4002", "업로드한 문서의 이름 너무 깁니다."),
+    FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "FILE4003", "업로드한 문서의 전체 크기가 너무 큽니다."),
+    FILE_FORMAT_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FILE4001", "업로드한 파일의 형식이 잘못 되었습니다."),
+    FILE_NAME_DUPLICATED(HttpStatus.CONFLICT, "FILE4005", "업로드한 파일 이름이 중복됩니다."),
+    FILE_TOO_MANY(HttpStatus.PAYLOAD_TOO_LARGE, "FILE4006", "업로드한 파일이 너무 많습니다."),
     ;
     //
     private final HttpStatus httpStatus;

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -13,7 +13,7 @@ public enum ErrorStatus {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _EMPTY_FIELD(HttpStatus.NO_CONTENT, "COMMON404", "입력 값이 누락되었습니다."),
-    
+
     CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "CLUBADMIN401", "인증이 필요합니다."),
 
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATIONFORM401", "ApplicationForm이 없습니다."),
@@ -23,7 +23,6 @@ public enum ErrorStatus {
     APPLICATION_NOT_PRESENT(HttpStatus.NOT_FOUND, "APPLICATION402", "존재하지 않는 신청입니다."),
     APPLICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "APPLICATION403", "인증이 필요합니다."),
     APPLICATION_NOT_CHANGEABLE(HttpStatus.FORBIDDEN, "APPLICATION404", "해당 신청의 상태를 변경할 수 없습니다."),
-
 
 
     //  파일 업로드 관련

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -14,6 +14,7 @@ public enum ErrorStatus {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _EMPTY_FIELD(HttpStatus.NO_CONTENT, "COMMON404", "입력 값이 누락되었습니다."),
     
+    CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "APPLICATION401", "인증이 필요합니다."),
 
     ;
     //

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -27,12 +27,17 @@ public enum ErrorStatus {
 
 
     //  파일 업로드 관련
-    FILE_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "FILE4001", "업로드한 문서의 이름이 없습니다."),
-    FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FILE4002", "업로드한 문서의 이름 너무 깁니다."),
-    FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "FILE4003", "업로드한 문서의 전체 크기가 너무 큽니다."),
-    FILE_FORMAT_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FILE4001", "업로드한 파일의 형식이 잘못 되었습니다."),
-    FILE_NAME_DUPLICATED(HttpStatus.CONFLICT, "FILE4005", "업로드한 파일 이름이 중복됩니다."),
-    FILE_TOO_MANY(HttpStatus.PAYLOAD_TOO_LARGE, "FILE4006", "업로드한 파일이 너무 많습니다."),
+    FILE_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "FILE401", "업로드한 파일의 이름이 없습니다."),
+    FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FILE402", "업로드한 파일의 이름 너무 깁니다."),
+    FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "FILE403", "업로드한 파일의 전체 크기가 너무 큽니다."),
+    FILE_FORMAT_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "FILE401", "업로드한 파일의 형식이 잘못 되었습니다."),
+    FILE_NAME_DUPLICATED(HttpStatus.CONFLICT, "FILE405", "업로드한 파일 이름이 중복됩니다."),
+    FILE_TOO_MANY(HttpStatus.PAYLOAD_TOO_LARGE, "FILE406", "업로드한 파일이 너무 많습니다."),
+    FILE_FORMAT_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE407", "파일의 형식을 찾을 수 없습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "FILE408", "파일 업로드에 실패했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "FILE409", "파일 삭제에 실패했습니다. (Delete 함수 false 반환)"),
+    FILE_DELETE_FAILED_CRITICAL(HttpStatus.UNPROCESSABLE_ENTITY, "FILE410", "파일 삭제에 실패했습니다. (권한 등의 기타 오류)"),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE411", "파일이 존재하지 않습니다.")
     ;
     //
     private final HttpStatus httpStatus;

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -14,7 +14,7 @@ public enum ErrorStatus {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _EMPTY_FIELD(HttpStatus.NO_CONTENT, "COMMON404", "입력 값이 누락되었습니다."),
     
-    CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "APPLICATION401", "인증이 필요합니다."),
+    CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "CLUBADMIN401", "인증이 필요합니다."),
 
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATIONFORM401", "ApplicationForm이 없습니다."),
     APPLICATION_FORM_IN_USE(HttpStatus.CONFLICT, "APPLICATIONFORM402", "이미 사용중인 지원서 양식입니다."),

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -16,6 +16,7 @@ public enum ErrorStatus {
     
     CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "APPLICATION401", "인증이 필요합니다."),
 
+    APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATIONFORM401", "ApplicationForm이 없습니다."),
     ;
     //
     private final HttpStatus httpStatus;

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -17,6 +17,7 @@ public enum ErrorStatus {
     CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "APPLICATION401", "인증이 필요합니다."),
 
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATIONFORM401", "ApplicationForm이 없습니다."),
+    APPLICATION_FORM_IN_USE(HttpStatus.CONFLICT, "APPLICATIONFORM402", "이미 사용중인 지원서 양식입니다."),
     ;
     //
     private final HttpStatus httpStatus;

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -20,6 +20,9 @@ public enum ErrorStatus {
     APPLICATION_FORM_IN_USE(HttpStatus.CONFLICT, "APPLICATIONFORM402", "이미 사용중인 지원서 양식입니다."),
 
     APPLICATION_DUPLICATED(HttpStatus.CONFLICT, "APPLICATION401", "신청이 중복되었습니다."),
+    APPLICATION_NOT_PRESENT(HttpStatus.NOT_FOUND, "APPLICATION402", "존재하지 않는 신청입니다."),
+    APPLICATION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "APPLICATION403", "인증이 필요합니다."),
+    APPLICATION_NOT_CHANGEABLE(HttpStatus.FORBIDDEN, "APPLICATION404", "해당 신청의 상태를 변경할 수 없습니다."),
 
 
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -10,6 +10,7 @@ public enum InSuccess {
 
     _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
 
+    APPLICATION_FORM_CREATED(HttpStatus.OK, "APPLICATIONFORM200", "지원서 양식 저장에 성공했습니다."),
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -18,6 +18,7 @@ public enum InSuccess {
 
     APPLICATION_SUCCESS(HttpStatus.OK, "APPLICATION201", "신청에 성공했습니다."),
     APPLICATION_DELETED(HttpStatus.OK, "APPLICATION202", "신청 취소에 성공했습니다."),
+    APPLICATION_CHANGED(HttpStatus.OK, "APPLICATION203", "신청 수정에 성공했습니다."),
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -11,6 +11,8 @@ public enum InSuccess {
     _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
 
     APPLICATION_FORM_CREATED(HttpStatus.OK, "APPLICATIONFORM200", "지원서 양식 저장에 성공했습니다."),
+    APPLICATION_FORM_GET_ADMIN_INFO(HttpStatus.OK, "APPLICATIONFORM201", "관리자용 지원서 양식 조회에 성공했습니다."),
+    APPLICATION_FORM_GET_USER_INFO(HttpStatus.OK, "APPLICATIONFORM202", "사용자용 지원서 양식 조회에 성공했습니다."),
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -16,7 +16,8 @@ public enum InSuccess {
     APPLICATION_FORM_DELETED(HttpStatus.OK, "APPLICATIONFORM203", "지원서 양식 삭제에 성공했습니다."),
     APPLICATION_FORM_CHANGED(HttpStatus.OK, "APPLICATIONFORM204", "지원서 양식 수정에 성공했습니다."),
 
-    APPLICATION_SUCCESS(HttpStatus.OK, "APPLICATION201", "신청에 성공했습니다.")
+    APPLICATION_SUCCESS(HttpStatus.OK, "APPLICATION201", "신청에 성공했습니다."),
+    APPLICATION_DELETED(HttpStatus.OK, "APPLICATION202", "신청 취소에 성공했습니다."),
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -16,6 +16,8 @@ public enum InSuccess {
     APPLICATION_FORM_DELETED(HttpStatus.OK, "APPLICATIONFORM203", "지원서 양식 삭제에 성공했습니다."),
     APPLICATION_FORM_CHANGED(HttpStatus.OK, "APPLICATIONFORM204", "지원서 양식 수정에 성공했습니다."),
 
+    APPLICATION_SUCCESS(HttpStatus.OK, "APPLICATION201", "신청에 성공했습니다.")
+
     ;
 
     private final HttpStatus httpStatus;

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -13,6 +13,7 @@ public enum InSuccess {
     APPLICATION_FORM_CREATED(HttpStatus.OK, "APPLICATIONFORM200", "지원서 양식 저장에 성공했습니다."),
     APPLICATION_FORM_GET_ADMIN_INFO(HttpStatus.OK, "APPLICATIONFORM201", "관리자용 지원서 양식 조회에 성공했습니다."),
     APPLICATION_FORM_GET_USER_INFO(HttpStatus.OK, "APPLICATIONFORM202", "사용자용 지원서 양식 조회에 성공했습니다."),
+    APPLICATION_FORM_DELETED(HttpStatus.OK, "APPLICATIONFORM203", "지원서 양식 삭제에 성공했습니다."),
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -19,6 +19,8 @@ public enum InSuccess {
     APPLICATION_SUCCESS(HttpStatus.OK, "APPLICATION201", "신청에 성공했습니다."),
     APPLICATION_DELETED(HttpStatus.OK, "APPLICATION202", "신청 취소에 성공했습니다."),
     APPLICATION_CHANGED(HttpStatus.OK, "APPLICATION203", "신청 수정에 성공했습니다."),
+    APPLICATION_HISTORY_GET_SUCCESS(HttpStatus.OK, "APPLICATION204", "지원 내역 조회에 성공했습니다."),
+
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -14,6 +14,7 @@ public enum InSuccess {
     APPLICATION_FORM_GET_ADMIN_INFO(HttpStatus.OK, "APPLICATIONFORM201", "관리자용 지원서 양식 조회에 성공했습니다."),
     APPLICATION_FORM_GET_USER_INFO(HttpStatus.OK, "APPLICATIONFORM202", "사용자용 지원서 양식 조회에 성공했습니다."),
     APPLICATION_FORM_DELETED(HttpStatus.OK, "APPLICATIONFORM203", "지원서 양식 삭제에 성공했습니다."),
+    APPLICATION_FORM_CHANGED(HttpStatus.OK, "APPLICATIONFORM204", "지원서 양식 수정에 성공했습니다."),
 
     ;
 

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -181,25 +181,27 @@ public class ApplicationService {
             }
         }
 
-        //업로드 할 파일 검증 (길이, 확장자 등)
-        fileService.validateCertificateFiles(files);
+        if(files!=null){
+            //업로드 할 파일 검증 (길이, 확장자 등)
+            fileService.validateFiles(files);
 
-        if (files.size() > 5) {
-            throw new CustomException(ErrorStatus.FILE_TOO_MANY);
-        }
+            if (files.size() > 5) {
+                throw new CustomException(ErrorStatus.FILE_TOO_MANY);
+            }
 
-        //uploadFiles
-        for (MultipartFile file : files) {
-            String fileName = file.getOriginalFilename();
-            String uuid = UUID.randomUUID().toString();
-            String fileUrl = objectStorageService.uploadObject(objectStorageServiceConfig.getApplicationDocsDir(), uuid, file);
+            //uploadFiles
+            for (MultipartFile file : files) {
+                String fileName = file.getOriginalFilename();
+                String uuid = UUID.randomUUID().toString();
+                String fileUrl = objectStorageService.uploadObject(objectStorageServiceConfig.getApplicationDocsDir(), uuid, file);
 
-            ApplicationDocs applicationDocs = ApplicationDocs.builder()
-                    .applicationId(toApplyClub.getApplyId())
-                    .fileName(fileName)
-                    .fileUrl(fileUrl)
-                    .build();
-            applicationDocsRepository.save(applicationDocs);
+                ApplicationDocs applicationDocs = ApplicationDocs.builder()
+                        .applicationId(toApplyClub.getApplyId())
+                        .fileName(fileName)
+                        .fileUrl(fileUrl)
+                        .build();
+                applicationDocsRepository.save(applicationDocs);
+            }
         }
 
         Application application = Application.builder()

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -1,0 +1,65 @@
+package club.gach_dong.service;
+
+import club.gach_dong.domain.Application;
+import club.gach_dong.domain.ApplicationDocs;
+import club.gach_dong.domain.ApplicationForm;
+import club.gach_dong.domain.ApplicationFormStatus;
+import club.gach_dong.dto.request.ApplicationRequestDTO;
+import club.gach_dong.dto.response.ApplicationResponseDTO;
+import club.gach_dong.exception.CustomException;
+import club.gach_dong.gcp.ObjectStorageService;
+import club.gach_dong.gcp.ObjectStorageServiceConfig;
+import club.gach_dong.repository.ApplicationDocsRepository;
+import club.gach_dong.repository.ApplicationFormRepository;
+import club.gach_dong.repository.ApplicationRepository;
+import club.gach_dong.response.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+
+    private final ApplicationFormRepository applicationFormRepository;
+    @Transactional
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest){
+
+        //Verify Club Admin Auth with Club_id, User_Id
+        //Get userId
+        Long userId = 0L;
+
+        checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
+
+        ApplicationForm applicationForm = ApplicationForm.builder()
+                .applicationFormStatus(ApplicationFormStatus.valueOf(toCreateApplicationFormDTO.getStatus()))
+                .formName(toCreateApplicationFormDTO.getFormName())
+                .applyId(toCreateApplicationFormDTO.getApplyId())
+                .body(toCreateApplicationFormDTO.getFormBody())
+                .build();
+
+        ApplicationForm createdApplicationForm = applicationFormRepository.save(applicationForm);
+
+        return ApplicationResponseDTO.ToCreateApplicationFormDTO.builder()
+                .applicationFormId(createdApplicationForm.getId())
+                .build();
+    }
+
+    public void checkAuth(Long userId, Long applyId){
+        //Check Auth
+        //Communicate with club server to check userId has auth with applyId
+        //Club server have to get clubId with applyId and check userId auth with clubId
+
+        if(false){
+            throw new CustomException(ErrorStatus.CLUB_UNAUTHORIZED);
+        }
+
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -225,4 +225,31 @@ public class ApplicationService {
 
     }
 
+    @Transactional
+    public void deleteApplication(Long applyId, HttpServletRequest httpServletRequest) {
+
+        //Get userId
+        Long userId = 0L;
+
+        Optional<Application> applicationOptional = applicationRepository.findByUserIdAndApplyId(userId, applyId);
+
+        //If application not present
+        if(applicationOptional.isEmpty()){
+            throw new CustomException(ErrorStatus.APPLICATION_NOT_PRESENT);
+        }
+
+        Application application = applicationOptional.get();
+
+        //If application is not owner of user
+        if(!userId.equals(application.getUserId())){
+            throw new CustomException(ErrorStatus.APPLICATION_UNAUTHORIZED);
+        }
+
+        //If application couldn't be deleted.
+        if(Objects.equals(application.getApplicationStatus(), "SAVED")){
+            throw new CustomException(ErrorStatus.APPLICATION_NOT_CHANGEABLE);
+        }
+
+        applicationRepository.delete(application);
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -131,4 +131,26 @@ public class ApplicationService {
         applicationFormRepository.deleteById(formId);
     }
 
+
+    @Transactional
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest){
+
+        //Verify Club Admin Auth with Club_id, User_Id
+        //Get userId
+        Long userId = 0L;
+
+        checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
+
+        Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
+        if(applicationFormOptional.isEmpty()){
+            throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
+        }
+
+        ApplicationForm applicationForm = applicationFormOptional.get();
+
+        deleteApplicationForm(formId, httpServletRequest);
+
+        return createApplicationForm(toCreateApplicationFormDTO, httpServletRequest);
+    }
+
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -266,9 +266,8 @@ public class ApplicationService {
         if (!applicationDocsList.isEmpty()) {
             for (ApplicationDocs applicationDocs : applicationDocsList) {
                 objectStorageService.deleteObject(applicationDocs.getFileUrl());
+                applicationDocsRepository.deleteByApplicationId(applicationDocs.getApplicationId());
             }
-
-            applicationDocsRepository.deleteAllByApplicationId(application.getId());
         }
 
         applicationRepository.delete(application);

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -69,6 +69,7 @@ public class ApplicationService {
 
     }
 
+    @Transactional(readOnly = true)
     public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest){
 
         //Verify Club Admin Auth with Club_id, User_Id
@@ -94,6 +95,7 @@ public class ApplicationService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, HttpServletRequest httpServletRequest){
 
         //Get userId

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -258,6 +260,14 @@ public class ApplicationService {
         if(Objects.equals(application.getApplicationStatus(), "SAVED")){
             throw new CustomException(ErrorStatus.APPLICATION_NOT_CHANGEABLE);
         }
+
+        List<ApplicationDocs> applicationDocsList = applicationDocsRepository.findAllByApplicationId(applyId);
+
+        for(ApplicationDocs applicationDocs : applicationDocsList){
+            objectStorageService.deleteObject(applicationDocs.getFileUrl());
+        }
+
+        applicationDocsRepository.deleteAllByApplicationId(application.getId());
 
         applicationRepository.delete(application);
     }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -185,7 +185,7 @@ public class ApplicationService {
             throw new CustomException(ErrorStatus.FILE_TOO_MANY);
         }
 
-        //uploadCertFiles
+        //uploadFiles
         for (MultipartFile file : files) {
             String fileName = file.getOriginalFilename();
             String uuid = UUID.randomUUID().toString();

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -208,6 +208,10 @@ public class ApplicationService {
                 .clubName(toApplyClub.getClubName())
                 .build();
 
+        if(Objects.equals(application.getApplicationStatus(), "TEMP")){
+            deleteApplication(applyId, httpServletRequest);
+        }
+
         Application applicationId = applicationRepository.save(application);
 
         return ApplicationResponseDTO.ToCreateApplicationDTO.builder()

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -252,4 +252,10 @@ public class ApplicationService {
 
         applicationRepository.delete(application);
     }
+
+    @Transactional
+    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
+        deleteApplication(applyId, httpServletRequest);
+        return createApplication(applyId, files, toApplyClub, httpServletRequest);
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -263,11 +263,13 @@ public class ApplicationService {
 
         List<ApplicationDocs> applicationDocsList = applicationDocsRepository.findAllByApplicationId(applyId);
 
-        for(ApplicationDocs applicationDocs : applicationDocsList){
-            objectStorageService.deleteObject(applicationDocs.getFileUrl());
-        }
+        if(!applicationDocsList.isEmpty()){
+            for(ApplicationDocs applicationDocs : applicationDocsList){
+                objectStorageService.deleteObject(applicationDocs.getFileUrl());
+            }
 
-        applicationDocsRepository.deleteAllByApplicationId(application.getId());
+            applicationDocsRepository.deleteAllByApplicationId(application.getId());
+        }
 
         applicationRepository.delete(application);
     }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -62,4 +62,49 @@ public class ApplicationService {
         }
 
     }
+
+    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest){
+
+        //Verify Club Admin Auth with Club_id, User_Id
+        //Get userId
+        Long userId = 0L;
+
+
+        Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
+        if(applicationFormOptional.isEmpty()){
+            throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
+        }
+
+        ApplicationForm applicationForm = applicationFormOptional.get();
+
+        checkAuth(userId, applicationForm.getApplyId());
+
+        return ApplicationResponseDTO.ToGetFormInfoAdminDTO.builder()
+                .formId(applicationForm.getId())
+                .formName(applicationForm.getFormName())
+                .formBody(applicationForm.getBody())
+                .formStatus(String.valueOf(applicationForm.getApplicationFormStatus()))
+                .formSettings(null)
+                .build();
+    }
+
+    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, HttpServletRequest httpServletRequest){
+
+        //Get userId
+        Long userId = 0L;
+
+
+        Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
+        if(applicationFormOptional.isEmpty()){
+            throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
+        }
+
+        ApplicationForm applicationForm = applicationFormOptional.get();
+
+        return ApplicationResponseDTO.ToGetFormInfoUserDTO.builder()
+                .formId(applicationForm.getId())
+                .formName(applicationForm.getFormName())
+                .formBody(applicationForm.getBody())
+                .build();
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -39,7 +39,7 @@ public class ApplicationService {
     private final ApplicationDocsRepository applicationDocsRepository;
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest){
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
 
         //Verify Club Admin Auth with Club_id, User_Id
         //Get userId
@@ -61,19 +61,19 @@ public class ApplicationService {
                 .build();
     }
 
-    public void checkAuth(Long userId, Long applyId){
+    public void checkAuth(Long userId, Long applyId) {
         //Check Auth
         //Communicate with club server to check userId has auth with applyId
         //Club server have to get clubId with applyId and check userId auth with clubId
 
-        if(false){
+        if (false) {
             throw new CustomException(ErrorStatus.CLUB_UNAUTHORIZED);
         }
 
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest){
+    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest) {
 
         //Verify Club Admin Auth with Club_id, User_Id
         //Get userId
@@ -81,7 +81,7 @@ public class ApplicationService {
 
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
-        if(applicationFormOptional.isEmpty()){
+        if (applicationFormOptional.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
         }
 
@@ -99,14 +99,14 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, HttpServletRequest httpServletRequest){
+    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, HttpServletRequest httpServletRequest) {
 
         //Get userId
         Long userId = 0L;
 
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
-        if(applicationFormOptional.isEmpty()){
+        if (applicationFormOptional.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
         }
 
@@ -120,14 +120,14 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest){
+    public void deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
         //Verify Club Admin Auth with Club_id, User_Id
         //Get userId
         Long userId = 0L;
 
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
-        if(applicationFormOptional.isEmpty()){
+        if (applicationFormOptional.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
         }
 
@@ -135,7 +135,7 @@ public class ApplicationService {
 
         checkAuth(userId, applicationForm.getApplyId());
 
-        if(applicationForm.getApplicationFormStatus() == ApplicationFormStatus.IN_USE){
+        if (applicationForm.getApplicationFormStatus() == ApplicationFormStatus.IN_USE) {
             throw new CustomException(ErrorStatus.APPLICATION_FORM_IN_USE);
         }
 
@@ -144,7 +144,7 @@ public class ApplicationService {
 
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest){
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
 
         //Verify Club Admin Auth with Club_id, User_Id
         //Get userId
@@ -153,7 +153,7 @@ public class ApplicationService {
         checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
-        if(applicationFormOptional.isEmpty()){
+        if (applicationFormOptional.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
         }
 
@@ -165,7 +165,7 @@ public class ApplicationService {
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest){
+    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
 
         //Verify it is valid apply
         //In constructions!!!
@@ -176,14 +176,14 @@ public class ApplicationService {
 
         //Check it is duplicated
         Optional<Application> applicationOptional = applicationRepository.findByUserIdAndApplyId(userId, applyId);
-        if(applicationOptional.isPresent()){
+        if (applicationOptional.isPresent()) {
             Application application = applicationOptional.get();
-            if(!Objects.equals(application.getApplicationStatus(), "TEMP")){
+            if (!Objects.equals(application.getApplicationStatus(), "TEMP")) {
                 throw new CustomException(ErrorStatus.APPLICATION_DUPLICATED);
             }
         }
 
-        if(files!=null){
+        if (files != null) {
             //업로드 할 파일 검증 (길이, 확장자 등)
             fileService.validateFiles(files);
 
@@ -215,7 +215,7 @@ public class ApplicationService {
                 .clubName(toApplyClub.getClubName())
                 .build();
 
-        if(Objects.equals(application.getApplicationStatus(), "TEMP")){
+        if (Objects.equals(application.getApplicationStatus(), "TEMP")) {
             deleteApplication(applyId, httpServletRequest);
         }
 
@@ -226,11 +226,11 @@ public class ApplicationService {
                 .build();
     }
 
-    public void checkValidApply(Long applyId){
+    public void checkValidApply(Long applyId) {
 
         //send to apply
 
-        if(false){
+        if (false) {
             throw new CustomException(ErrorStatus._BAD_REQUEST);
         }
 
@@ -245,26 +245,26 @@ public class ApplicationService {
         Optional<Application> applicationOptional = applicationRepository.findByUserIdAndApplyId(userId, applyId);
 
         //If application not present
-        if(applicationOptional.isEmpty()){
+        if (applicationOptional.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_NOT_PRESENT);
         }
 
         Application application = applicationOptional.get();
 
         //If application is not owner of user
-        if(!userId.equals(application.getUserId())){
+        if (!userId.equals(application.getUserId())) {
             throw new CustomException(ErrorStatus.APPLICATION_UNAUTHORIZED);
         }
 
         //If application couldn't be deleted.
-        if(Objects.equals(application.getApplicationStatus(), "SAVED")){
+        if (Objects.equals(application.getApplicationStatus(), "SAVED")) {
             throw new CustomException(ErrorStatus.APPLICATION_NOT_CHANGEABLE);
         }
 
         List<ApplicationDocs> applicationDocsList = applicationDocsRepository.findAllByApplicationId(applyId);
 
-        if(!applicationDocsList.isEmpty()){
-            for(ApplicationDocs applicationDocs : applicationDocsList){
+        if (!applicationDocsList.isEmpty()) {
+            for (ApplicationDocs applicationDocs : applicationDocsList) {
                 objectStorageService.deleteObject(applicationDocs.getFileUrl());
             }
 
@@ -281,7 +281,7 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(HttpServletRequest httpServletRequest){
+    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(HttpServletRequest httpServletRequest) {
 
         //Get userId
         Long userId = 0L;

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -107,4 +107,28 @@ public class ApplicationService {
                 .formBody(applicationForm.getBody())
                 .build();
     }
+
+    @Transactional
+    public void deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest){
+        //Verify Club Admin Auth with Club_id, User_Id
+        //Get userId
+        Long userId = 0L;
+
+
+        Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
+        if(applicationFormOptional.isEmpty()){
+            throw new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND);
+        }
+
+        ApplicationForm applicationForm = applicationFormOptional.get();
+
+        checkAuth(userId, applicationForm.getApplyId());
+
+        if(applicationForm.getApplicationFormStatus() == ApplicationFormStatus.IN_USE){
+            throw new CustomException(ErrorStatus.APPLICATION_FORM_IN_USE);
+        }
+
+        applicationFormRepository.deleteById(formId);
+    }
+
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -159,7 +159,7 @@ public class ApplicationService {
 
         ApplicationForm applicationForm = applicationFormOptional.get();
 
-        deleteApplicationForm(formId, httpServletRequest);
+        applicationFormRepository.deleteById(formId);
 
         return createApplicationForm(toCreateApplicationFormDTO, httpServletRequest);
     }
@@ -198,7 +198,7 @@ public class ApplicationService {
                 String fileUrl = objectStorageService.uploadObject(objectStorageServiceConfig.getApplicationDocsDir(), uuid, file);
 
                 ApplicationDocs applicationDocs = ApplicationDocs.builder()
-                        .applicationId(toApplyClub.getApplyId())
+                        .applicationId(applyId)
                         .fileName(fileName)
                         .fileUrl(fileUrl)
                         .build();

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -263,5 +264,27 @@ public class ApplicationService {
     public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
         deleteApplication(applyId, httpServletRequest);
         return createApplication(applyId, files, toApplyClub, httpServletRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(HttpServletRequest httpServletRequest){
+
+        //Get userId
+        Long userId = 0L;
+
+        List<Application> applicationList = applicationRepository.findAllByUserId(userId);
+
+        List<ApplicationResponseDTO.ToGetApplicationHistoryDTO> applicationHistoryDTOs = applicationList.stream()
+                .map(application -> ApplicationResponseDTO.ToGetApplicationHistoryDTO.builder()
+                        .applicationId(application.getId())
+                        .clubName(application.getClubName())
+                        .status(application.getApplicationStatus())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ApplicationResponseDTO.ToGetApplicationHistoryListDTO.builder()
+                .toGetApplicationHistoryDTO(applicationHistoryDTOs)
+                .build();
+
     }
 }

--- a/application-service/src/main/java/club/gach_dong/service/FileService.java
+++ b/application-service/src/main/java/club/gach_dong/service/FileService.java
@@ -1,0 +1,46 @@
+package club.gach_dong.service;
+
+import club.gach_dong.exception.CustomException;
+import club.gach_dong.response.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private static final long MAX_TOTAL_CERTIFICATE_FILE_SIZE = 104857600L;
+    private static final Set<String> ALLOWED_CERTIFICATE_FILE_EXTENSIONS = Set.of(".pdf", ".docx", ".xlsx", ".hwp", ".jpg", ".png"); // 허용된 확장자 목록
+    private static final long MAX_CERTIFICATE_FILE_LENGTH = 30L;
+
+    public void validateCertificateFiles(List<MultipartFile> certificateFiles) throws CustomException {
+        long totalCertificateFileSize = 0L;
+        for (MultipartFile certificateFile : certificateFiles) {
+            String fileName = certificateFile.getOriginalFilename();
+
+            //파일 이름 검증
+            if (fileName == null) {
+                throw new CustomException(ErrorStatus.FILE_NAME_NOT_FOUND);
+            } else if (fileName.length() > MAX_CERTIFICATE_FILE_LENGTH) {
+                throw new CustomException(ErrorStatus.FILE_NAME_TOO_LONG);
+            } else {
+                String fileExtension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+                totalCertificateFileSize += certificateFile.getSize();
+
+                //확장자 검증
+                if (!ALLOWED_CERTIFICATE_FILE_EXTENSIONS.contains(fileExtension)) {
+                    throw new CustomException(ErrorStatus.FILE_FORMAT_NOT_SUPPORTED);
+                }
+            }
+        }
+
+        //모든 파일의 전체 크기 검증
+        if (totalCertificateFileSize > MAX_TOTAL_CERTIFICATE_FILE_SIZE) {
+            throw new CustomException(ErrorStatus.FILE_TOO_LARGE);
+        }
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/service/FileService.java
+++ b/application-service/src/main/java/club/gach_dong/service/FileService.java
@@ -17,10 +17,10 @@ public class FileService {
     private static final Set<String> ALLOWED_CERTIFICATE_FILE_EXTENSIONS = Set.of(".pdf", ".docx", ".xlsx", ".hwp", ".jpg", ".png"); // 허용된 확장자 목록
     private static final long MAX_CERTIFICATE_FILE_LENGTH = 30L;
 
-    public void validateCertificateFiles(List<MultipartFile> certificateFiles) throws CustomException {
+    public void validateFiles(List<MultipartFile> files) throws CustomException {
         long totalCertificateFileSize = 0L;
-        for (MultipartFile certificateFile : certificateFiles) {
-            String fileName = certificateFile.getOriginalFilename();
+        for (MultipartFile file : files) {
+            String fileName = file.getOriginalFilename();
 
             //파일 이름 검증
             if (fileName == null) {
@@ -29,7 +29,7 @@ public class FileService {
                 throw new CustomException(ErrorStatus.FILE_NAME_TOO_LONG);
             } else {
                 String fileExtension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
-                totalCertificateFileSize += certificateFile.getSize();
+                totalCertificateFileSize += file.getSize();
 
                 //확장자 검증
                 if (!ALLOWED_CERTIFICATE_FILE_EXTENSIONS.contains(fileExtension)) {

--- a/application-service/src/main/resources/application.yml
+++ b/application-service/src/main/resources/application.yml
@@ -27,8 +27,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 50MB
-      max-request-size: 50MB
+      max-file-size: 100MB
+      max-request-size: 100MB
 
   cloud:
     gcp:

--- a/application-service/src/main/resources/application.yml
+++ b/application-service/src/main/resources/application.yml
@@ -24,6 +24,12 @@ spring:
         use_sql_comments: true
         dialect: org.hibernate.dialect.MySQLDialect
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 50MB
+      max-request-size: 50MB
+
   cloud:
     gcp:
       storage:

--- a/application-service/src/main/resources/application.yml
+++ b/application-service/src/main/resources/application.yml
@@ -23,3 +23,13 @@ spring:
         show_sql: true
         use_sql_comments: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+  cloud:
+    gcp:
+      storage:
+        credentials:
+          location: ${GCP_SERVICE_KEY}
+        project-id: ${GCP_PROJECT_ID}
+        bucket: ${GCP_BUCKET_NAME}
+        path:
+          applicationDocs: ${GCP_APPLICATION}


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/20

1. 인증/인가 관련해서 처리가 완료되지 못했습니다. 해당 내용에 대하여 전달 받은 후 Issue 새로 생성해서 작업에 들어갈 예정입니다.
- userId관련
- club admin권한 관련
- security 관련 config
- 인증 인가 관련 예외 처리
- Entity 및 DTO도 수정될 수 있음

2. 다른 서비스와 통신해야 될 부분도 아직 설정이 안되었습니다. 이 부분도 위와 같이 처리할 예정입니다.
- 지원 시 유효한 해당 지원이 유효한 지원인지?
- 등등....

## 2. 구현한 내용 또는 수정한 내용

Application Domain의 모든 Entity 구현
- application
- applicationDocs
- applicationForm

! Entity 변경 가능성 및 Transaction Lock 시 장애 전파 방지를 위하여 연관 관계는 제외합니다.

GCP Storage 저장 및 삭제 기능 구현 및 설정
- uploadObject -> bucket에 파일 추가
- deleteObject -> bucket에 파일 삭제

! 파일 형식 및 파일 용량, 파일 개수 제한 등은 조정될 수 있습니다.

지원서 양식 관련 기능 구현
 - createApplicationForm -> 지원서 양식 생성
 - changeApplicationForm -> 지원서 양식 수정
 - deleteApplicationForm -> 지원서 양식 삭제
 - getFormInfoUser -> 지원서 양식 조회(사용자용)
 - getFormInfoAdmin -> 관리자 지원서 양식 조회(관리자용)

지원 관련 기능 구현

-  createApplication -> 사용자 지원
-  changeApplication -> 사용자 지원 수정
-  deleteApplication -> 사용자 지원 삭제
- getApplicationHistoryList -> 지원 내역 조회


## 3. TODO

- [x] 지원서 양식 생성
- [x] 지원서 양식 수정
- [x] 지원서 양식 삭제
- [x] 지원서 양식 조회(사용자용)
- [x] 관리자 지원서 양식 조회(관리자용)
- [x] 사용자 지원
- [x] 사용자 지원 수정
- [x] 사용자 지원 삭제
- [x] 지원 내역 조회

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->