### PR TITLE
fix: auth-service의 api를 /public과 분리하도록 수정

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
@@ -2,8 +2,6 @@ package club.gach_dong.api;
 
 import club.gach_dong.dto.AuthResponse;
 import club.gach_dong.dto.ChangePasswordDto;
-import club.gach_dong.dto.LoginDto;
-import club.gach_dong.dto.RegistrationDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,35 +13,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 public interface AuthApiSpecification {
-
-    @Operation(summary = "이메일 인증 코드 발송", description = "이메일로 유효시간 3분의 6자리의 인증 코드를 발송합니다.")
-    @PostMapping("/send_verification_code")
-    ResponseEntity<String> sendVerificationCode(
-            @Parameter(description = "사용자의 이메일 주소") @RequestParam String email);
-
-    @Operation(
-            summary = "회원가입",
-            description = "회원가입을 완료합니다. \n" +
-                    "- email: 사용자 이메일 (gachon.ac.kr 도메인 고정) \n" +
-                    "- code: 6자리의 이메일 인증 코드 \n" +
-                    "- password: 사용자 비밀번호 (8~16자, 영문, 숫자, 특수문자 포함) \n" +
-                    "- name: 사용자 이름 \n" +
-                    "- role: 사용자 역할 (USER, ADMIN) "
-    )
-    @PostMapping("/register")
-    ResponseEntity<String> completeRegistration(
-            @Parameter(description = "회원가입 정보") @Valid @RequestBody RegistrationDto registrationDto);
-
-    @Operation(summary = "사용자 로그인", description = "사용자가 로그인합니다.")
-    @PostMapping("/login")
-    ResponseEntity<AuthResponse> login(
-            @Parameter(description = "로그인 정보") @Valid @RequestBody LoginDto loginDto);
-
-    @Operation(summary = "비밀번호 재발급", description = "이메일 인증 코드를 입력하여 임시 비밀번호를 재발급합니다.")
-    @PostMapping("/reset_password")
-    ResponseEntity<String> resetPassword(
-            @Parameter(description = "사용자의 이메일 주소") @RequestParam String email,
-            @Parameter(description = "인증 코드") @RequestParam String code);
 
     @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 변경합니다.")
     @PostMapping("/change_password")

--- a/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
@@ -1,0 +1,37 @@
+package club.gach_dong.api;
+
+import club.gach_dong.dto.AuthResponse;
+import club.gach_dong.dto.RegistrationDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Public 인증/인가 API", description = "Public한 인증/인가가 필요한 API")
+@RestController
+@RequestMapping("/api/v1/public")
+public interface PublicAuthApiSpecification {
+
+    @Operation(summary = "이메일 인증 코드 발송", description = "이메일로 유효시간 3분의 6자리의 인증 코드를 발송합니다.")
+    @PostMapping("/send_verification_code")
+    ResponseEntity<String> sendVerificationCode(
+            @Parameter(description = "사용자의 이메일 주소") @RequestParam String email);
+
+    @Operation(summary = "회원가입", description = "회원가입을 완료합니다.")
+    @PostMapping("/register")
+    ResponseEntity<String> completeRegistration(
+            @Parameter(description = "회원가입 정보") @Valid @RequestBody RegistrationDto registrationDto);
+
+    @Operation(summary = "사용자 로그인", description = "사용자가 로그인합니다.")
+    @PostMapping("/login")
+    ResponseEntity<AuthResponse> login(
+            @Parameter(description = "로그인 정보") @Valid @RequestBody LoginDto loginDto);
+
+    @Operation(summary = "비밀번호 재발급", description = "이메일 인증 코드를 입력하여 임시 비밀번호를 재발급합니다.")
+    @PostMapping("/reset_password")
+    ResponseEntity<String> resetPassword(
+            @Parameter(description = "사용자의 이메일 주소") @RequestParam String email,
+            @Parameter(description = "인증 코드") @RequestParam String code);
+}

--- a/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
@@ -3,10 +3,10 @@ package club.gach_dong.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import club.gach_dong.api.AuthApiSpecification;
+import club.gach_dong.api.PublicAuthApiSpecification; // Public API 인터페이스 추가
 import club.gach_dong.dto.AuthResponse;
 import club.gach_dong.dto.ChangePasswordDto;
 import club.gach_dong.dto.LoginDto;
@@ -17,10 +17,9 @@ import club.gach_dong.util.JwtUtil;
 
 @RestController
 @RequiredArgsConstructor
-public class AuthController implements AuthApiSpecification {
+public class AuthController implements AuthApiSpecification, PublicAuthApiSpecification {
 
     private final UserService userService;
-    private final JavaMailSender mailSender;
     private final JwtUtil jwtUtil;
 
     @Override
@@ -37,14 +36,12 @@ public class AuthController implements AuthApiSpecification {
     public ResponseEntity<String> completeRegistration(@Valid @RequestBody RegistrationDto registrationDto) {
         try {
             userService.verifyCode(registrationDto.getEmail(), registrationDto.getCode());
-
             userService.completeRegistration(
                     registrationDto.getEmail(),
                     registrationDto.getPassword(),
                     registrationDto.getName(),
                     registrationDto.getRole()
             );
-
             return ResponseEntity.ok("회원가입이 완료되었습니다.");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원가입 실패: " + e.getMessage());


### PR DESCRIPTION
## 1. 관련 이슈

#41 

## 2. 구현한 내용 또는 수정한 내용

auth-service의 다음과 같은 내용을 수정 및 변경하였습니다.

## 3. TODO

- [x] PublicApiSpecifcation 생성
- [x] ApiSpecification Public과 분리
- [x] Authcontroller 수정

## 4. 배포 전 Checklist
@EeeasyCode 
<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->