### PR TITLE
fix: public controller 분리 및 각 api에 대한 swagger 문서 연동 오류 수정

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
@@ -1,7 +1,6 @@
 package club.gach_dong.api;
 
 import club.gach_dong.dto.AuthResponse;
-import club.gach_dong.dto.LoginDto;
 import club.gach_dong.dto.RegistrationDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,9 +9,9 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Public 인증/인가 API", description = "Public한 인증/인가가 필요한 API")
+@Tag(name = "Public 인증/인가 API", description = "Public한 사용자 인증 및 인가 관련 API")
 @RestController
-@RequestMapping("/api/v1/public")
+@RequestMapping("/public/api/v1")
 public interface PublicAuthApiSpecification {
 
     @Operation(summary = "이메일 인증 코드 발송", description = "이메일로 유효시간 3분의 6자리의 인증 코드를 발송합니다.")
@@ -20,7 +19,12 @@ public interface PublicAuthApiSpecification {
     ResponseEntity<String> sendVerificationCode(
             @Parameter(description = "사용자의 이메일 주소") @RequestParam String email);
 
-    @Operation(summary = "회원가입", description = "회원가입을 완료합니다.")
+    @Operation(summary = "회원가입", description = "회원가입을 완료합니다. \n" +
+            "- email: 사용자 이메일 (gachon.ac.kr 도메인) \n" +
+            "- code: 6자리의 이메일 인증 코드 \n" +
+            "- password: 8~16자 영문, 숫자, 특수문자를 포함한 비밀번호 \n" +
+            "- name: 사용자 이름 \n" +
+            "- role: ADMIN, USER")
     @PostMapping("/register")
     ResponseEntity<String> completeRegistration(
             @Parameter(description = "회원가입 정보") @Valid @RequestBody RegistrationDto registrationDto);

--- a/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
@@ -6,78 +6,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import club.gach_dong.api.AuthApiSpecification;
-import club.gach_dong.api.PublicAuthApiSpecification; // Public API 인터페이스 추가
-import club.gach_dong.dto.AuthResponse;
 import club.gach_dong.dto.ChangePasswordDto;
-import club.gach_dong.dto.LoginDto;
-import club.gach_dong.dto.RegistrationDto;
 import club.gach_dong.entity.User;
 import club.gach_dong.service.UserService;
 import club.gach_dong.util.JwtUtil;
 
 @RestController
 @RequiredArgsConstructor
-public class AuthController implements AuthApiSpecification, PublicAuthApiSpecification {
+public class AuthController implements AuthApiSpecification {
 
     private final UserService userService;
     private final JwtUtil jwtUtil;
-
-    @Override
-    public ResponseEntity<String> sendVerificationCode(@RequestParam String email) {
-        try {
-            userService.sendVerificationCode(email);
-            return ResponseEntity.ok("인증 코드가 이메일로 발송되었습니다.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("인증 코드 발송 실패: " + e.getMessage());
-        }
-    }
-
-    @Override
-    public ResponseEntity<String> completeRegistration(@Valid @RequestBody RegistrationDto registrationDto) {
-        try {
-            userService.verifyCode(registrationDto.getEmail(), registrationDto.getCode());
-            userService.completeRegistration(
-                    registrationDto.getEmail(),
-                    registrationDto.getPassword(),
-                    registrationDto.getName(),
-                    registrationDto.getRole()
-            );
-            return ResponseEntity.ok("회원가입이 완료되었습니다.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원가입 실패: " + e.getMessage());
-        }
-    }
-
-    @Override
-    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginDto loginDto) {
-        User user = userService.findByEmail(loginDto.getEmail());
-
-        if (user == null || !userService.checkPassword(user, loginDto.getPassword())) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(AuthResponse.withMessage("이메일 또는 비밀번호가 올바르지 않습니다."));
-        }
-
-        if (!user.isEnabled()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(AuthResponse.withMessage("계정이 활성화되지 않았습니다."));
-        }
-
-        String token = jwtUtil.generateToken(user);
-        return ResponseEntity.ok(AuthResponse.of(token));
-    }
-
-    @Override
-    public ResponseEntity<String> resetPassword(@RequestParam String email, @RequestParam String code) {
-        try {
-            userService.verifyCode(email, code);
-            String newPassword = userService.generateRandomPassword();
-            userService.resetPassword(email, newPassword);
-            userService.sendResetPasswordEmail(email, newPassword);
-            return ResponseEntity.ok("임시 비밀번호가 이메일로 발송되었습니다.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("비밀번호 재발급 실패: " + e.getMessage());
-        }
-    }
 
     @Override
     public ResponseEntity<String> changePassword(@RequestHeader("Authorization") String token, @Valid @RequestBody ChangePasswordDto changePasswordDto) {

--- a/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
@@ -1,0 +1,79 @@
+package club.gach_dong.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
+import club.gach_dong.api.PublicAuthApiSpecification;
+import club.gach_dong.dto.AuthResponse;
+import club.gach_dong.dto.RegistrationDto;
+import club.gach_dong.dto.LoginDto;
+import club.gach_dong.entity.User;
+import club.gach_dong.service.UserService;
+import club.gach_dong.util.JwtUtil;
+
+@RestController
+@RequiredArgsConstructor
+public class PublicAuthController implements PublicAuthApiSpecification {
+
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public ResponseEntity<String> sendVerificationCode(@RequestParam String email) {
+        try {
+            userService.sendVerificationCode(email);
+            return ResponseEntity.ok("인증 코드가 이메일로 발송되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("인증 코드 발송 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public ResponseEntity<String> completeRegistration(@Valid @RequestBody RegistrationDto registrationDto) {
+        try {
+            userService.verifyCode(registrationDto.getEmail(), registrationDto.getCode());
+            userService.completeRegistration(
+                    registrationDto.getEmail(),
+                    registrationDto.getPassword(),
+                    registrationDto.getName(),
+                    registrationDto.getRole()
+            );
+            return ResponseEntity.ok("회원가입이 완료되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원가입 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginDto loginDto) {
+        User user = userService.findByEmail(loginDto.getEmail());
+
+        if (user == null || !userService.checkPassword(user, loginDto.getPassword())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(AuthResponse.withMessage("이메일 또는 비밀번호가 올바르지 않습니다."));
+        }
+
+        if (!user.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(AuthResponse.withMessage("계정이 활성화되지 않았습니다."));
+        }
+
+        String token = jwtUtil.generateToken(user);
+        return ResponseEntity.ok(AuthResponse.of(token));
+    }
+
+    @Override
+    public ResponseEntity<String> resetPassword(@RequestParam String email, @RequestParam String code) {
+        try {
+            userService.verifyCode(email, code);
+            String newPassword = userService.generateRandomPassword();
+            userService.resetPassword(email, newPassword);
+            userService.sendResetPasswordEmail(email, newPassword);
+            return ResponseEntity.ok("임시 비밀번호가 이메일로 발송되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("비밀번호 재발급 실패: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 1. 관련 이슈
#43 

## 2. 구현한 내용 또는 수정한 내용

auth-service의 기존 api와 /public api를 분리합니다.
controller를 분리하여 swagger 문서에 오류없이 분리되도록 수정합니다.

## 3. TODO

- [x] Authcontroller / PublicAuthController 분리
- [x] AuthApiSpecification 수정
- [x] PublicAuthApiSpecification 수정

## 4. 배포 전 Checklist
@EeeasyCode 