### PR TITLE
[FEAT] 지원서 양식 및 지원 관련 기능 인증/인가 처리 추가

### DIFF
--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -66,5 +66,11 @@ public interface ApplicationApiSpecification {
     @DeleteMapping("/apply/{applyId}")
     ResForm<?> deleteApplication(@PathVariable("applyId") Long applyId, HttpServletRequest httpServletRequest);
 
+    @Operation(summary = "사용자 지원 상태 변경 API", description = "지원 ID를 이용해 지원 상태를 변경합니다.")
+    @PostMapping("/status/{applyId}")
+    ResForm<?> changeApplicationStatus(@PathVariable("applyId") Long applyId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,  HttpServletRequest httpServletRequest);
+
+
+
 }
 

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -30,11 +30,11 @@ public interface ApplicationApiSpecification {
     ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.")
-    @GetMapping("/application/list")
+    @GetMapping("/list")
     ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.")
-    @PostMapping("/application/admin/form/create")
+    @PostMapping("/admin/form/create")
     ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(@Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원 API", description = "동아리에 지원합니다.")
@@ -47,11 +47,11 @@ public interface ApplicationApiSpecification {
     );
 
     @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.")
-    @PutMapping("/application/admin/form/{form_id}")
+    @PutMapping("/admin/form/{form_id}")
     ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(@PathVariable("form_id") Long formId, @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원 수정 API", description = "동아리에 지원을 수정합니다.")
-    @PutMapping(value = "/application/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping(value = "/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(
             @PathVariable("apply_id") Long applyId,
             @RequestPart(value = "certificateDocs", required = true) @Parameter(description = "업로드할 문서 리스트") List<MultipartFile> certificateDocs,

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -40,7 +40,7 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.")
     @GetMapping("/list")
-    ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(
+    ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getApplicationHistory(
             HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.")

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -82,10 +82,10 @@ public interface ApplicationApiSpecification {
     ResForm<?> deleteApplication(@PathVariable("applyId") Long applyId, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자 지원 상태 변경 API", description = "지원 ID를 이용해 지원 상태를 변경합니다.")
-    @PostMapping("/status/{applyId}")
-    ResForm<?> changeApplicationStatus(@PathVariable("applyId") Long applyId,
-                                       ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
-                                       HttpServletRequest httpServletRequest);
+    @PutMapping("/status")
+    ResForm<?> changeApplicationStatus(
+            @Valid @RequestBody ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
+            HttpServletRequest httpServletRequest);
 
 
 }

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -8,12 +8,19 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.validation.annotation.Validated;
-
 import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "지원 API", description = "동아리 지원 관련 API")
 @RestController
@@ -23,19 +30,24 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "관리자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.")
     @GetMapping("/admin/form/{formId}")
-    ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long formId,
+                                                                           HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.")
     @GetMapping("/form/{formId}")
-    ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(@PathVariable("formId") Long formId,
+                                                                         HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.")
     @GetMapping("/list")
-    ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(
+            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.")
     @PostMapping("/admin/form/create")
-    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(@Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
+            @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원 API", description = "동아리에 지원합니다.")
     @PostMapping(value = "/{apply_id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -48,7 +60,10 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.")
     @PutMapping("/admin/form/{form_id}")
-    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(@PathVariable("form_id") Long formId, @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest);
+    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(
+            @PathVariable("form_id") Long formId,
+            @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원 수정 API", description = "동아리에 지원을 수정합니다.")
     @PutMapping(value = "/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -68,8 +83,9 @@ public interface ApplicationApiSpecification {
 
     @Operation(summary = "사용자 지원 상태 변경 API", description = "지원 ID를 이용해 지원 상태를 변경합니다.")
     @PostMapping("/status/{applyId}")
-    ResForm<?> changeApplicationStatus(@PathVariable("applyId") Long applyId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,  HttpServletRequest httpServletRequest);
-
+    ResForm<?> changeApplicationStatus(@PathVariable("applyId") Long applyId,
+                                       ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
+                                       HttpServletRequest httpServletRequest);
 
 
 }

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -8,11 +8,10 @@ import club.gach_dong.response.status.InSuccess;
 import club.gach_dong.service.ApplicationService;
 import club.gach_dong.service.AuthorizationService;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,51 +21,71 @@ public class ApplicationController implements ApplicationApiSpecification {
     public final AuthorizationService authorizationService;
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId,
+                                                                                  HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId, userId);
+        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId,
+                userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_ADMIN_INFO, toGetFormInfoAdminDTO);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long formId, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long formId,
+                                                                                HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToGetFormInfoUserDTO toGetFormInfoUserDTO = applicationService.getFormInfoUser(formId, userId);
+        ApplicationResponseDTO.ToGetFormInfoUserDTO toGetFormInfoUserDTO = applicationService.getFormInfoUser(formId,
+                userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetFormInfoUserDTO);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getApplicationHistory(
+            HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToGetApplicationHistoryListDTO toGetApplicationHistoryListDTO = applicationService.getApplicationHistoryList(userId);
+        ApplicationResponseDTO.ToGetApplicationHistoryListDTO toGetApplicationHistoryListDTO = applicationService.getApplicationHistoryList(
+                userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetApplicationHistoryListDTO);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
+            ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO,
+            HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(createApplicationFormDTO, userId);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(
+                createApplicationFormDTO, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CREATED, toCreateApplicationFormDTO);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId,
+                                                                                    List<MultipartFile> files,
+                                                                                    ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+                                                                                    HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(applyId, files, toApplyClub, userId);
+        ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(
+                applyId, files, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_SUCCESS, toCreateApplicationDTO);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId,
+                                                                                            ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+                                                                                            HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, userId);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(
+                formId, toCreateApplicationFormDTO, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId,
+                                                                                    List<MultipartFile> certificateDocs,
+                                                                                    ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+                                                                                    HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToCreateApplicationDTO toChangeApplicationDTO = applicationService.changeApplication(applyId, certificateDocs, toApplyClub, userId);
+        ApplicationResponseDTO.ToCreateApplicationDTO toChangeApplicationDTO = applicationService.changeApplication(
+                applyId, certificateDocs, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_CHANGED, toChangeApplicationDTO);
     }
 
@@ -85,7 +104,9 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<?> changeApplicationStatus(Long applyId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus, HttpServletRequest httpServletRequest) {
+    public ResForm<?> changeApplicationStatus(Long applyId,
+                                              ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
+                                              HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
         applicationService.changeApplicationStatus(userId, toChangeApplicationStatus);
         return ResForm.onSuccess(InSuccess.APPLICATION_STATUS_CHANGED, null);

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -23,71 +23,71 @@ public class ApplicationController implements ApplicationApiSpecification {
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_ADMIN_INFO, toGetFormInfoAdminDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long formId, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToGetFormInfoUserDTO toGetFormInfoUserDTO = applicationService.getFormInfoUser(formId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetFormInfoUserDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToGetApplicationHistoryListDTO toGetApplicationHistoryListDTO = applicationService.getApplicationHistoryList(userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetApplicationHistoryListDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(createApplicationFormDTO, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CREATED, toCreateApplicationFormDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(applyId, files, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_SUCCESS, toCreateApplicationDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         ApplicationResponseDTO.ToCreateApplicationDTO toChangeApplicationDTO = applicationService.changeApplication(applyId, certificateDocs, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_CHANGED, toChangeApplicationDTO);
     }
 
     @Override
     public ResForm<?> deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         applicationService.deleteApplicationForm(formId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_DELETED, null);
     }
 
     @Override
     public ResForm<?> deleteApplication(Long applyId, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
+        String userId = authorizationService.getUserId(httpServletRequest);
         applicationService.deleteApplication(applyId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_DELETED, null);
     }
 
     @Override
     public ResForm<?> changeApplicationStatus(Long applyId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus, HttpServletRequest httpServletRequest) {
-        Long userId = authorizationService.getUserId(httpServletRequest);
-        applicationService.changeApplicationStatus(applyId, toChangeApplicationStatus);
+        String userId = authorizationService.getUserId(httpServletRequest);
+        applicationService.changeApplicationStatus(userId, toChangeApplicationStatus);
         return ResForm.onSuccess(InSuccess.APPLICATION_STATUS_CHANGED, null);
     }
 

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -84,5 +84,12 @@ public class ApplicationController implements ApplicationApiSpecification {
         return ResForm.onSuccess(InSuccess.APPLICATION_DELETED, null);
     }
 
+    @Override
+    public ResForm<?> changeApplicationStatus(Long applyId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus, HttpServletRequest httpServletRequest) {
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        applicationService.changeApplicationStatus(applyId, toChangeApplicationStatus);
+        return ResForm.onSuccess(InSuccess.APPLICATION_STATUS_CHANGED, null);
+    }
+
     ;
 }

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -6,6 +6,7 @@ import club.gach_dong.dto.response.ApplicationResponseDTO;
 import club.gach_dong.response.ResForm;
 import club.gach_dong.response.status.InSuccess;
 import club.gach_dong.service.ApplicationService;
+import club.gach_dong.service.AuthorizationService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,58 +19,68 @@ import java.util.List;
 public class ApplicationController implements ApplicationApiSpecification {
 
     public final ApplicationService applicationService;
+    public final AuthorizationService authorizationService;
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_ADMIN_INFO, toGetFormInfoAdminDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long formId, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToGetFormInfoUserDTO toGetFormInfoUserDTO = applicationService.getFormInfoUser(formId, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToGetFormInfoUserDTO toGetFormInfoUserDTO = applicationService.getFormInfoUser(formId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetFormInfoUserDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getaApplicationHistory(HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToGetApplicationHistoryListDTO toGetApplicationHistoryListDTO = applicationService.getApplicationHistoryList(httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToGetApplicationHistoryListDTO toGetApplicationHistoryListDTO = applicationService.getApplicationHistoryList(userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_USER_INFO, toGetApplicationHistoryListDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(createApplicationFormDTO, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(createApplicationFormDTO, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CREATED, toCreateApplicationFormDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(applyId, files, toApplyClub, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(applyId, files, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_SUCCESS, toCreateApplicationDTO);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(formId, toCreateApplicationFormDTO, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
     }
 
     @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(Long applyId, List<MultipartFile> certificateDocs, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
-        ApplicationResponseDTO.ToCreateApplicationDTO toChangeApplicationDTO = applicationService.changeApplication(applyId, certificateDocs, toApplyClub, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationDTO toChangeApplicationDTO = applicationService.changeApplication(applyId, certificateDocs, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_CHANGED, toChangeApplicationDTO);
     }
 
     @Override
     public ResForm<?> deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
-        applicationService.deleteApplicationForm(formId, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        applicationService.deleteApplicationForm(formId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_FORM_DELETED, null);
     }
 
     @Override
     public ResForm<?> deleteApplication(Long applyId, HttpServletRequest httpServletRequest) {
-        applicationService.deleteApplication(applyId, httpServletRequest);
+        Long userId = authorizationService.getUserId(httpServletRequest);
+        applicationService.deleteApplication(applyId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_DELETED, null);
     }
 

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -104,8 +104,7 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<?> changeApplicationStatus(Long applyId,
-                                              ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
+    public ResForm<?> changeApplicationStatus(ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
                                               HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
         applicationService.changeApplicationStatus(userId, toChangeApplicationStatus);

--- a/application-service/src/main/java/club/gach_dong/domain/Application.java
+++ b/application-service/src/main/java/club/gach_dong/domain/Application.java
@@ -16,7 +16,7 @@ public class Application {
     private Long id;
 
     @Column(name = "user_id", nullable = false)
-    private Long userId;
+    private String userId;
 
     @Column(name = "apply_id", nullable = false)
     private Long applyId;

--- a/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
@@ -41,4 +41,14 @@ public class ApplicationRequestDTO {
         @Size(max = 80, message = "동이리 이름이 너무 큽니다.")
         private String clubName;
     }
+
+    @Getter
+    public static class ToChangeApplicationStatus{
+        @NotNull(message = "변경할 Application Id가 누락되었습니다.")
+        private Long applicationId;
+
+        @NotNull(message = "변경할 application 상태를 입력해 주세요.")
+        @Size(max = 80, message = "상태가 너무 깁니다.")
+        private String status;
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageService.java
@@ -21,8 +21,7 @@ public class ObjectStorageService {
     private final Storage storage;
 
     private static final Logger logger = LogManager.getLogger(ObjectStorageService.class);
-
-
+    
     /**
      * @param directory: ObjectStorageConfig 및 application.yml에 정의되어있는 object storage 내 디렉토리
      * @param objectKey: 업로드할 파일의 이름

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageServiceConfig.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageServiceConfig.java
@@ -1,14 +1,14 @@
 package club.gach_dong.gcp;
+
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
-
-import java.io.IOException;
 
 @Getter
 @Configuration
@@ -30,7 +30,6 @@ public class ObjectStorageServiceConfig {
 
         ClassPathResource resource = new ClassPathResource(credentialsJson);
         GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
-
 
         return StorageOptions.newBuilder()
                 .setCredentials(credentials)

--- a/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageServiceConfig.java
+++ b/application-service/src/main/java/club/gach_dong/gcp/ObjectStorageServiceConfig.java
@@ -6,10 +6,9 @@ import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Getter
 @Configuration
@@ -23,15 +22,16 @@ public class ObjectStorageServiceConfig {
     @Value("${spring.cloud.gcp.storage.path.applicationDocs}")
     private String applicationDocsDir;
 
-    @Value("${GOOGLE_APPLICATION_CREDENTIALS_JSON}")
+    @Value("${spring.cloud.gcp.storage.credentials.location}")
     private String credentialsJson;
 
     @Bean
     public Storage storage() throws IOException {
-        GoogleCredentials credentials;
-        try (ByteArrayInputStream stream = new ByteArrayInputStream(credentialsJson.getBytes(StandardCharsets.UTF_8))) {
-            credentials = GoogleCredentials.fromStream(stream);
-        }
+
+        ClassPathResource resource = new ClassPathResource(credentialsJson);
+        GoogleCredentials credentials = GoogleCredentials.fromStream(resource.getInputStream());
+
+
         return StorageOptions.newBuilder()
                 .setCredentials(credentials)
                 .setProjectId(projectId)

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -2,6 +2,9 @@ package club.gach_dong.repository;
 
 import club.gach_dong.domain.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +16,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     Optional<Application> findByUserIdAndApplyId(Long userId, Long applyId);
 
     List<Application> findAllByUserId(Long userId);
+
+    @Modifying
+    @Query("UPDATE application a SET a.applicationStatus = :status WHERE a = :application")
+    void updateApplicationStatus(@Param("status") String status, @Param("application") Application application);
 }

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -13,9 +13,9 @@ import java.util.Optional;
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
-    Optional<Application> findByUserIdAndApplyId(Long userId, Long applyId);
+    Optional<Application> findByUserIdAndApplyId(String userId, Long applyId);
 
-    List<Application> findAllByUserId(Long userId);
+    List<Application> findAllByUserId(String userId);
 
     @Modifying
     @Query("UPDATE application a SET a.applicationStatus = :status WHERE a = :application")

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorStatus.java
@@ -16,6 +16,8 @@ public enum ErrorStatus {
 
     CLUB_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "CLUBADMIN401", "인증이 필요합니다."),
 
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER401", "사용자 ID를 찾을 수 없습니다."),
+
     APPLICATION_FORM_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATIONFORM401", "ApplicationForm이 없습니다."),
     APPLICATION_FORM_IN_USE(HttpStatus.CONFLICT, "APPLICATIONFORM402", "이미 사용중인 지원서 양식입니다."),
 

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -20,6 +20,7 @@ public enum InSuccess {
     APPLICATION_DELETED(HttpStatus.OK, "APPLICATION202", "신청 취소에 성공했습니다."),
     APPLICATION_CHANGED(HttpStatus.OK, "APPLICATION203", "신청 수정에 성공했습니다."),
     APPLICATION_HISTORY_GET_SUCCESS(HttpStatus.OK, "APPLICATION204", "지원 내역 조회에 성공했습니다."),
+    APPLICATION_STATUS_CHANGED(HttpStatus.OK, "APPLICATION205", "지원 상태 수정에 성공했습니다."),
 
 
     ;

--- a/application-service/src/main/java/club/gach_dong/restClient/HeaderInterceptor.java
+++ b/application-service/src/main/java/club/gach_dong/restClient/HeaderInterceptor.java
@@ -1,6 +1,8 @@
 package club.gach_dong.restClient;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Enumeration;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -9,13 +11,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.io.IOException;
-import java.util.Enumeration;
-
 @Component
 public class HeaderInterceptor implements ClientHttpRequestInterceptor {
     @Override
-    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
         ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
         if (attributes != null) {
             HttpServletRequest httpRequest = attributes.getRequest();

--- a/application-service/src/main/java/club/gach_dong/restClient/HeaderInterceptor.java
+++ b/application-service/src/main/java/club/gach_dong/restClient/HeaderInterceptor.java
@@ -1,0 +1,35 @@
+package club.gach_dong.restClient;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.io.IOException;
+import java.util.Enumeration;
+
+@Component
+public class HeaderInterceptor implements ClientHttpRequestInterceptor {
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            HttpServletRequest httpRequest = attributes.getRequest();
+            Enumeration<String> headerNames = httpRequest.getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                if (headerName.equalsIgnoreCase("reqq-id")) {
+                    String reqqIdValue = httpRequest.getHeader(headerName);
+                    request.getHeaders().set("reqq-id", reqqIdValue);
+                    break;
+                }
+            }
+        }
+
+        return execution.execute(request, body);
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/restClient/RestClientConfig.java
+++ b/application-service/src/main/java/club/gach_dong/restClient/RestClientConfig.java
@@ -1,0 +1,19 @@
+package club.gach_dong.restClient;
+
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@AllArgsConstructor
+public class RestClientConfig {
+    private final HeaderInterceptor headerInterceptor;
+
+    @Bean
+    RestClient restClient() {
+        return RestClient.builder()
+                .requestInterceptor(headerInterceptor)
+                .build();
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -262,4 +262,21 @@ public class ApplicationService {
                 .build();
 
     }
+
+    @Transactional
+    public void changeApplicationStatus(Long userId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus){
+
+        Optional<Application> applicationOptional = applicationRepository.findById(toChangeApplicationStatus.getApplicationId());
+
+        if(applicationOptional.isEmpty()){
+            throw new CustomException(ErrorStatus.APPLICATION_NOT_PRESENT);
+        }
+
+        Application application = applicationOptional.get();
+
+        //Verify Club Admin Auth with Apply_Id, User_Id
+        authorizationService.getAuthByUserIdAndApplyId(userId, application.getApplyId());
+
+        applicationRepository.updateApplicationStatus(toChangeApplicationStatus.getStatus(), application);
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -37,11 +37,9 @@ public class ApplicationService {
     private final ApplicationDocsRepository applicationDocsRepository;
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, Long userId) {
 
         //Verify Club Admin Auth with Club_id, User_Id
-        //Get userId
-        Long userId = 0L;
 
         checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
 
@@ -71,11 +69,10 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, HttpServletRequest httpServletRequest) {
+    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, Long userId) {
 
         //Verify Club Admin Auth with Club_id, User_Id
-        //Get userId
-        Long userId = 0L;
+        //In Construction!!
 
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
@@ -97,11 +94,7 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, HttpServletRequest httpServletRequest) {
-
-        //Get userId
-        Long userId = 0L;
-
+    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, Long userId) {
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {
@@ -118,10 +111,8 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
+    public void deleteApplicationForm(Long formId, Long userId) {
         //Verify Club Admin Auth with Club_id, User_Id
-        //Get userId
-        Long userId = 0L;
 
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
@@ -142,11 +133,9 @@ public class ApplicationService {
 
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, HttpServletRequest httpServletRequest) {
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, Long userId) {
 
         //Verify Club Admin Auth with Club_id, User_Id
-        //Get userId
-        Long userId = 0L;
 
         checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
 
@@ -159,18 +148,15 @@ public class ApplicationService {
 
         applicationFormRepository.deleteById(formId);
 
-        return createApplicationForm(toCreateApplicationFormDTO, httpServletRequest);
+        return createApplicationForm(toCreateApplicationFormDTO, userId);
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
+    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, Long userId) {
 
         //Verify it is valid apply
         //In constructions!!!
         checkValidApply(applyId);
-
-        //Get userId
-        Long userId = 0L;
 
         //Check it is duplicated
         Optional<Application> applicationOptional = applicationRepository.findByUserIdAndApplyId(userId, applyId);
@@ -214,7 +200,7 @@ public class ApplicationService {
                 .build();
 
         if (Objects.equals(application.getApplicationStatus(), "TEMP")) {
-            deleteApplication(applyId, httpServletRequest);
+            deleteApplication(applyId, userId);
         }
 
         Application applicationId = applicationRepository.save(application);
@@ -235,10 +221,7 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void deleteApplication(Long applyId, HttpServletRequest httpServletRequest) {
-
-        //Get userId
-        Long userId = 0L;
+    public void deleteApplication(Long applyId, Long userId) {
 
         Optional<Application> applicationOptional = applicationRepository.findByUserIdAndApplyId(userId, applyId);
 
@@ -272,16 +255,13 @@ public class ApplicationService {
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, HttpServletRequest httpServletRequest) {
-        deleteApplication(applyId, httpServletRequest);
-        return createApplication(applyId, files, toApplyClub, httpServletRequest);
+    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, Long userId) {
+        deleteApplication(applyId, userId);
+        return createApplication(applyId, files, toApplyClub, userId);
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(HttpServletRequest httpServletRequest) {
-
-        //Get userId
-        Long userId = 0L;
+    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(Long userId) {
 
         List<Application> applicationList = applicationRepository.findAllByUserId(userId);
 

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -13,17 +13,15 @@ import club.gach_dong.repository.ApplicationDocsRepository;
 import club.gach_dong.repository.ApplicationFormRepository;
 import club.gach_dong.repository.ApplicationRepository;
 import club.gach_dong.response.status.ErrorStatus;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +36,8 @@ public class ApplicationService {
     private final AuthorizationService authorizationService;
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, String userId) {
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(
+            ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, String userId) {
 
         //Verify Club Admin Auth with Apply_Id, User_Id
         authorizationService.getAuthByUserIdAndApplyId(userId, toCreateApplicationFormDTO.getApplyId());
@@ -118,7 +117,9 @@ public class ApplicationService {
 
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, String userId) {
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId,
+                                                                                   ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+                                                                                   String userId) {
 
         //Verify Club Admin Auth with Apply_Id, User_Id
         authorizationService.getAuthByUserIdAndApplyId(userId, toCreateApplicationFormDTO.getApplyId());
@@ -136,7 +137,9 @@ public class ApplicationService {
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, String userId) {
+    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files,
+                                                                           ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+                                                                           String userId) {
 
         //Verify it is valid apply
         //In constructions!!!
@@ -163,7 +166,8 @@ public class ApplicationService {
             for (MultipartFile file : files) {
                 String fileName = file.getOriginalFilename();
                 String uuid = UUID.randomUUID().toString();
-                String fileUrl = objectStorageService.uploadObject(objectStorageServiceConfig.getApplicationDocsDir(), uuid, file);
+                String fileUrl = objectStorageService.uploadObject(objectStorageServiceConfig.getApplicationDocsDir(),
+                        uuid, file);
 
                 ApplicationDocs applicationDocs = ApplicationDocs.builder()
                         .applicationId(applyId)
@@ -239,7 +243,9 @@ public class ApplicationService {
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, String userId) {
+    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files,
+                                                                           ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
+                                                                           String userId) {
         deleteApplication(applyId, userId);
         return createApplication(applyId, files, toApplyClub, userId);
     }
@@ -264,11 +270,13 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void changeApplicationStatus(String userId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus){
+    public void changeApplicationStatus(String userId,
+                                        ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus) {
 
-        Optional<Application> applicationOptional = applicationRepository.findById(toChangeApplicationStatus.getApplicationId());
+        Optional<Application> applicationOptional = applicationRepository.findById(
+                toChangeApplicationStatus.getApplicationId());
 
-        if(applicationOptional.isEmpty()){
+        if (applicationOptional.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_NOT_PRESENT);
         }
 

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -38,7 +38,7 @@ public class ApplicationService {
     private final AuthorizationService authorizationService;
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, Long userId) {
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, String userId) {
 
         //Verify Club Admin Auth with Apply_Id, User_Id
         authorizationService.getAuthByUserIdAndApplyId(userId, toCreateApplicationFormDTO.getApplyId());
@@ -58,7 +58,7 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, Long userId) {
+    public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, String userId) {
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {
@@ -80,7 +80,7 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, Long userId) {
+    public ApplicationResponseDTO.ToGetFormInfoUserDTO getFormInfoUser(Long formId, String userId) {
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {
@@ -97,7 +97,7 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void deleteApplicationForm(Long formId, Long userId) {
+    public void deleteApplicationForm(Long formId, String userId) {
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {
@@ -118,7 +118,7 @@ public class ApplicationService {
 
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, Long userId) {
+    public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, String userId) {
 
         //Verify Club Admin Auth with Apply_Id, User_Id
         authorizationService.getAuthByUserIdAndApplyId(userId, toCreateApplicationFormDTO.getApplyId());
@@ -136,7 +136,7 @@ public class ApplicationService {
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, Long userId) {
+    public ApplicationResponseDTO.ToCreateApplicationDTO createApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, String userId) {
 
         //Verify it is valid apply
         //In constructions!!!
@@ -205,7 +205,7 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void deleteApplication(Long applyId, Long userId) {
+    public void deleteApplication(Long applyId, String userId) {
 
         Optional<Application> applicationOptional = applicationRepository.findByUserIdAndApplyId(userId, applyId);
 
@@ -239,13 +239,13 @@ public class ApplicationService {
     }
 
     @Transactional
-    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, Long userId) {
+    public ApplicationResponseDTO.ToCreateApplicationDTO changeApplication(Long applyId, List<MultipartFile> files, ApplicationRequestDTO.ToApplyClubDTO toApplyClub, String userId) {
         deleteApplication(applyId, userId);
         return createApplication(applyId, files, toApplyClub, userId);
     }
 
     @Transactional(readOnly = true)
-    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(Long userId) {
+    public ApplicationResponseDTO.ToGetApplicationHistoryListDTO getApplicationHistoryList(String userId) {
 
         List<Application> applicationList = applicationRepository.findAllByUserId(userId);
 
@@ -264,7 +264,7 @@ public class ApplicationService {
     }
 
     @Transactional
-    public void changeApplicationStatus(Long userId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus){
+    public void changeApplicationStatus(String userId, ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus){
 
         Optional<Application> applicationOptional = applicationRepository.findById(toChangeApplicationStatus.getApplicationId());
 

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -35,13 +35,13 @@ public class ApplicationService {
     private final ObjectStorageService objectStorageService;
     private final ObjectStorageServiceConfig objectStorageServiceConfig;
     private final ApplicationDocsRepository applicationDocsRepository;
+    private final AuthorizationService authorizationService;
 
     @Transactional
     public ApplicationResponseDTO.ToCreateApplicationFormDTO createApplicationForm(ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, Long userId) {
 
-        //Verify Club Admin Auth with Club_id, User_Id
-
-        checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
+        //Verify Club Admin Auth with Apply_Id, User_Id
+        authorizationService.getAuthByUserIdAndApplyId(userId, toCreateApplicationFormDTO.getApplyId());
 
         ApplicationForm applicationForm = ApplicationForm.builder()
                 .applicationFormStatus(ApplicationFormStatus.valueOf(toCreateApplicationFormDTO.getStatus()))
@@ -57,23 +57,8 @@ public class ApplicationService {
                 .build();
     }
 
-    public void checkAuth(Long userId, Long applyId) {
-        //Check Auth
-        //Communicate with club server to check userId has auth with applyId
-        //Club server have to get clubId with applyId and check userId auth with clubId
-
-        if (false) {
-            throw new CustomException(ErrorStatus.CLUB_UNAUTHORIZED);
-        }
-
-    }
-
     @Transactional(readOnly = true)
     public ApplicationResponseDTO.ToGetFormInfoAdminDTO getFormInfoAdmin(Long formId, Long userId) {
-
-        //Verify Club Admin Auth with Club_id, User_Id
-        //In Construction!!
-
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {
@@ -82,7 +67,8 @@ public class ApplicationService {
 
         ApplicationForm applicationForm = applicationFormOptional.get();
 
-        checkAuth(userId, applicationForm.getApplyId());
+        //Verify Club Admin Auth with Apply_Id, User_Id
+        authorizationService.getAuthByUserIdAndApplyId(userId, applicationForm.getApplyId());
 
         return ApplicationResponseDTO.ToGetFormInfoAdminDTO.builder()
                 .formId(applicationForm.getId())
@@ -112,8 +98,6 @@ public class ApplicationService {
 
     @Transactional
     public void deleteApplicationForm(Long formId, Long userId) {
-        //Verify Club Admin Auth with Club_id, User_Id
-
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {
@@ -122,7 +106,8 @@ public class ApplicationService {
 
         ApplicationForm applicationForm = applicationFormOptional.get();
 
-        checkAuth(userId, applicationForm.getApplyId());
+        //Verify Club Admin Auth with Apply_Id, User_Id
+        authorizationService.getAuthByUserIdAndApplyId(userId, applicationForm.getApplyId());
 
         if (applicationForm.getApplicationFormStatus() == ApplicationFormStatus.IN_USE) {
             throw new CustomException(ErrorStatus.APPLICATION_FORM_IN_USE);
@@ -135,9 +120,8 @@ public class ApplicationService {
     @Transactional
     public ApplicationResponseDTO.ToCreateApplicationFormDTO changeApplicationForm(Long formId, ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO, Long userId) {
 
-        //Verify Club Admin Auth with Club_id, User_Id
-
-        checkAuth(userId, toCreateApplicationFormDTO.getApplyId());
+        //Verify Club Admin Auth with Apply_Id, User_Id
+        authorizationService.getAuthByUserIdAndApplyId(userId, toCreateApplicationFormDTO.getApplyId());
 
         Optional<ApplicationForm> applicationFormOptional = applicationFormRepository.findById(formId);
         if (applicationFormOptional.isEmpty()) {

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -4,11 +4,19 @@ import club.gach_dong.exception.CustomException;
 import club.gach_dong.response.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
 
 @Service
 @RequiredArgsConstructor
 public class AuthorizationService {
+
+    @Value("${msa.url.club}")
+    private String clubUrl;
 
     private final static String MEMBER_ID_HEADER_KEY = "X-MEMBER-ID";
 
@@ -21,5 +29,39 @@ public class AuthorizationService {
 
         throw new CustomException(ErrorStatus.USER_NOT_FOUND);
 //        return null;
+    }
+
+    public void getAuthByUserIdAndApplyId(Long userId, Long applyId){
+
+        RestClient restClient = RestClient.create();
+
+        String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
+                .queryParam("userId", userId)
+                .queryParam("applyId", applyId)
+                .toUriString();
+
+        try {
+            Boolean result = restClient.get()
+                    .uri(uri)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(Boolean.class);
+
+            if(Boolean.TRUE.equals(result)){
+                return;
+            }else{
+                throw new CustomException(ErrorStatus._UNAUTHORIZED);
+            }
+//            return result != null ? result : false;
+
+        } catch (org.springframework.web.client.RestClientException e) {
+            System.err.println("REST 클라이언트 오류 발생: " + e.getMessage());
+            throw new CustomException(ErrorStatus._UNAUTHORIZED);
+//            return false;
+        } catch (Exception e) {
+            System.err.println("예상치 못한 오류 발생: " + e.getMessage());
+            throw new CustomException(ErrorStatus._UNAUTHORIZED);
+//            return false;
+        }
     }
 }

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -22,18 +22,18 @@ public class AuthorizationService {
 
     public final RestClient restClient;
 
-    public Long getUserId(HttpServletRequest httpServletRequest){
+    public String getUserId(HttpServletRequest httpServletRequest){
         String header = httpServletRequest.getHeader(MEMBER_ID_HEADER_KEY);
 
         if(header!=null){
-            return Long.parseLong(header);
+            return header;
         }
 
         throw new CustomException(ErrorStatus.USER_NOT_FOUND);
 //        return null;
     }
 
-    public void getAuthByUserIdAndApplyId(Long userId, Long applyId){
+    public void getAuthByUserIdAndApplyId(String userId, Long applyId){
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
                 .queryParam("userId", userId)

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -20,6 +20,8 @@ public class AuthorizationService {
 
     private final static String MEMBER_ID_HEADER_KEY = "X-MEMBER-ID";
 
+    public final RestClient restClient;
+
     public Long getUserId(HttpServletRequest httpServletRequest){
         String header = httpServletRequest.getHeader(MEMBER_ID_HEADER_KEY);
 
@@ -32,8 +34,6 @@ public class AuthorizationService {
     }
 
     public void getAuthByUserIdAndApplyId(Long userId, Long applyId){
-
-        RestClient restClient = RestClient.create();
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
                 .queryParam("userId", userId)

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -22,10 +22,10 @@ public class AuthorizationService {
 
     public final RestClient restClient;
 
-    public String getUserId(HttpServletRequest httpServletRequest){
+    public String getUserId(HttpServletRequest httpServletRequest) {
         String header = httpServletRequest.getHeader(MEMBER_ID_HEADER_KEY);
 
-        if(header!=null){
+        if (header != null) {
             return header;
         }
 
@@ -33,7 +33,7 @@ public class AuthorizationService {
 //        return null;
     }
 
-    public void getAuthByUserIdAndApplyId(String userId, Long applyId){
+    public void getAuthByUserIdAndApplyId(String userId, Long applyId) {
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
                 .queryParam("userId", userId)
@@ -47,9 +47,9 @@ public class AuthorizationService {
                     .retrieve()
                     .body(Boolean.class);
 
-            if(Boolean.TRUE.equals(result)){
+            if (Boolean.TRUE.equals(result)) {
                 return;
-            }else{
+            } else {
                 throw new CustomException(ErrorStatus._UNAUTHORIZED);
             }
 //            return result != null ? result : false;

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -1,0 +1,25 @@
+package club.gach_dong.service;
+
+import club.gach_dong.exception.CustomException;
+import club.gach_dong.response.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorizationService {
+
+    private final static String MEMBER_ID_HEADER_KEY = "X-MEMBER-ID";
+
+    public Long getUserId(HttpServletRequest httpServletRequest){
+        String header = httpServletRequest.getHeader(MEMBER_ID_HEADER_KEY);
+
+        if(header!=null){
+            return Long.parseLong(header);
+        }
+
+        throw new CustomException(ErrorStatus.USER_NOT_FOUND);
+//        return null;
+    }
+}

--- a/application-service/src/main/resources/application.yml
+++ b/application-service/src/main/resources/application.yml
@@ -39,3 +39,7 @@ spring:
         bucket: ${GCP_BUCKET_NAME}
         path:
           applicationDocs: ${GCP_APPLICATION}
+
+msa:
+  url:
+    club: ${CLUB_URL}


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/33

## 2. 구현한 내용 또는 수정한 내용

사용자 인증 및 인가 관련된 부분을 추가했습니다. (AuthorizationService.java 파일 참조)
- 사용자 ID는 httpServletRequest의 header에서 MEMBER_ID_HEADER_KEY에 해당하는 값으로 가져옵니다.
- 동아리 관리자 권한 확인은 userId와 applyId를 Query Parameter로 GET요청을 송신 후 수신된 Boolean값으로 권한을 확인합니다.
- 사용을 위하여 msa.url.club 부분의 환경 변수 설정이 필요합니다.

MSA 구현을 위한 restClient 설정이 추가되었습니다. 
- 현재 동아리 관리자 권한 확인을 위하여 사용됩니다.
- HeaderInterceptor를 통하여  reqq-id가 header에 있을 경우 해당 헤더를 restClient 사용 시 propagate 합니다. (HeaderInterceptor.java 참조)

지원 상태 변경 기능이 추가되었습니다.
- 동아리 관리자가 지원자의 상태를 변경함으로서 합격, 불합격, 서류 합격 등 상태를 변경할 수 있습니다.
- changeApplicationStatus 참조

Application 도메인의 userId 타입이 바뀌었습니다. 
- Long -> String
- userId를 사용하는 모든 코드의 userId 입력 형식 또한 그에 맞게 수정했습니다.

아래의 API URL이 수정되었습니다. (url에서 'Application' 단어 삭제)
- getApplicationHistory -> 사용자 지원 내역 목록 조회 API 
- createApplicationForm -> 동아리 지원서 양식 생성 요청 API
- changeApplicationForm -> 동아리 지원서 양식 수정 요청 API
- changeApplication -> 동아리 지원 수정 API

## 3. TODO

- [x] DB Entity 1차 확정 
- [x] userId 가져오는 Logic 구현
- [x] 동아리 관리자 권한 확인 Logic 구현
- [x] 인증/인가 관련 코드 예외 처리 마무리

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->