### PR TITLE
feat: 동아리 관리자용 접수된 지원서 내역 조회 기능 추가

### DIFF
--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -87,6 +87,12 @@ public interface ApplicationApiSpecification {
             @Valid @RequestBody ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
             HttpServletRequest httpServletRequest);
 
+    @Operation(summary = "지원 목록 조회 API", description = "지원 ID를 이용해 지원 목록을 조회합니다.")
+    @GetMapping("/admin/{applyId}")
+    ResForm<?> getClubApplicationList(@PathVariable("applyId") Long applyId, HttpServletRequest httpServletRequest);
 
+//    @Operation(summary = "지원 상세 조회 API", description = "지원 ID를 이용해 지원 내역을 조회합니다.")
+//    @DeleteMapping("/admin/{applicationId}")
+//    ResForm<?> getApplication(@PathVariable("applicationId") Long applicationId, HttpServletRequest httpServletRequest);
 }
 

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -111,5 +111,21 @@ public class ApplicationController implements ApplicationApiSpecification {
         return ResForm.onSuccess(InSuccess.APPLICATION_STATUS_CHANGED, null);
     }
 
+    @Override
+    public ResForm<ApplicationResponseDTO.ToGetApplicationListAdminDTO> getClubApplicationList(Long applyId,
+                                                                                               HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+
+        ApplicationResponseDTO.ToGetApplicationListAdminDTO toGetApplicationListAdminDTO = applicationService.getApplicationListAdmin(
+                userId, applyId);
+
+        return ResForm.onSuccess(InSuccess._OK, toGetApplicationListAdminDTO);
+    }
+
+//    @Override
+//    public ResForm<?> getApplication(Long applicationId, HttpServletRequest httpServletRequest) {
+//        return null;
+//    }
+
     ;
 }

--- a/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
@@ -79,4 +79,28 @@ public class ApplicationResponseDTO {
         private Long applyId;
     }
 
+    @Getter
+    @Builder
+    @Schema(description = "관리자용 동아리 지원 리스트 반환 DTO")
+    public static class ToGetApplicationListAdminDTO {
+        @Schema(description = "접수된 지원 목록 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private List<ToGetApplicationDTO> toGetApplicationDTO;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "관리자용 지원 내역 상세 조회 결과 반환 DTO")
+    public static class ToGetApplicationDTO {
+        @Schema(description = "지원 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private Long applicationId;
+
+        @Schema(description = "지원 상태(합격, 불합격, 서류 합격 등)", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private String status;
+
+        @Schema(description = "지원한 날짜", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private LocalDateTime submitDate;
+
+        @Schema(description = "답변 내용", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private Map<String, Object> applicationBody;
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -1,14 +1,13 @@
 package club.gach_dong.repository;
 
 import club.gach_dong.domain.Application;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
@@ -20,4 +19,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     @Modifying
     @Query("UPDATE application a SET a.applicationStatus = :status WHERE a = :application")
     void updateApplicationStatus(@Param("status") String status, @Param("application") Application application);
+
+    List<Application> findAllByApplyId(Long applyId);
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -289,4 +289,30 @@ public class ApplicationService {
 
         applicationRepository.updateApplicationStatus(toChangeApplicationStatus.getStatus(), application);
     }
+
+    @Transactional(readOnly = true)
+    public ApplicationResponseDTO.ToGetApplicationListAdminDTO getApplicationListAdmin(String userId, Long applyId) {
+
+        //Verify Club Admin Auth with Apply_Id, User_Id
+        authorizationService.getAuthByUserIdAndApplyId(userId, applyId);
+
+        List<Application> applicationList = applicationRepository.findAllByApplyId(applyId);
+
+        if (applicationList.isEmpty()) {
+            throw new CustomException(ErrorStatus.APPLICATION_NOT_PRESENT);
+        }
+        
+        List<ApplicationResponseDTO.ToGetApplicationDTO> toGetApplicationDTOs = applicationList.stream()
+                .map(application -> ApplicationResponseDTO.ToGetApplicationDTO.builder()
+                        .applicationId(application.getId())
+                        .status(application.getApplicationStatus())
+                        .submitDate(application.getSubmitDate())
+                        .applicationBody(application.getApplicationBody())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ApplicationResponseDTO.ToGetApplicationListAdminDTO.builder()
+                .toGetApplicationDTO(toGetApplicationDTOs)
+                .build();
+    }
 }


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/62

## 2. 구현한 내용 또는 수정한 내용

요청한 applyId에 해당되는 모든 지원의 내용을(지원 Id, 지원 상태, 답변 내용, 지원일) 반환합니다.

#### <추후 변경 가능한 사항>
applyId에 해당되는 모든 지원의 Id를 반환 후 해당 Id를 통하여 내용을 가져올지 아니면 applyId에 해당되는 모든 지원의 Id 포함한 모든 내용을 한번에 가져올지(현행) 확인이 안되어 특정 API에 주석 처리가 있을 수 있습니다.

## 3. TODO

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->