### PR TITLE
[Fix] user-service의 userId 필드 수정

### DIFF
--- a/user-service/src/main/java/club/gach_dong/annotation/RequestUserReferenceId.java
+++ b/user-service/src/main/java/club/gach_dong/annotation/RequestUserReferenceId.java
@@ -1,0 +1,13 @@
+package club.gach_dong.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Parameter(hidden = true)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.TYPE_PARAMETER})
+public @interface RequestUserReferenceId {
+}

--- a/user-service/src/main/java/club/gach_dong/api/UserApiSpecification.java
+++ b/user-service/src/main/java/club/gach_dong/api/UserApiSpecification.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "사용자 프로필 이미지 API", description = "사용자 프로필 이미지 관련 API")
+@RequestMapping("/api/v1")
 public interface UserApiSpecification {
 
     @Operation(summary = "프로필 이미지 업로드", description = "사용자의 프로필 이미지를 업로드합니다.")

--- a/user-service/src/main/java/club/gach_dong/api/UserApiSpecification.java
+++ b/user-service/src/main/java/club/gach_dong/api/UserApiSpecification.java
@@ -1,7 +1,7 @@
 package club.gach_dong.api;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.MediaType;
+import club.gach_dong.annotation.RequestUserReferenceId;
 import club.gach_dong.dto.request.UserProfileRequest;
 import club.gach_dong.dto.response.UserProfileResponse;
 import org.springframework.http.ResponseEntity;
@@ -19,21 +19,21 @@ public interface UserApiSpecification {
     ResponseEntity<UserProfileResponse> uploadProfileImage(
             @Parameter(description = "업로드할 이미지 파일", required = true)
             @ModelAttribute UserProfileRequest userProfileRequest,
-            HttpServletRequest httpServletRequest);
+            @Parameter(hidden = true) @RequestUserReferenceId String userReferenceId);
 
     @Operation(summary = "프로필 이미지 수정", description = "사용자의 프로필 이미지를 수정합니다.")
     @PostMapping(value = "/update-profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<UserProfileResponse> updateProfileImage(
             @Parameter(description = "수정할 이미지 파일") @ModelAttribute UserProfileRequest userProfileRequest,
-            HttpServletRequest httpServletRequest);
+            @Parameter(hidden = true) @RequestUserReferenceId String userReferenceId);
 
     @Operation(summary = "프로필 이미지 삭제", description = "사용자의 프로필 이미지를 삭제합니다.")
     @DeleteMapping("/delete-profile-image")
     ResponseEntity<String> deleteProfileImage(
-            @Parameter(description = "HTTP 요청 (X-MEMBER-ID 헤더 포함)") HttpServletRequest httpServletRequest);
+            @Parameter(hidden = true) @RequestUserReferenceId String userReferenceId);
 
     @Operation(summary = "프로필 이미지 조회", description = "사용자의 프로필 이미지를 조회합니다.")
     @GetMapping("/profile-image")
     ResponseEntity<String> getProfileImage(
-            @Parameter(description = "HTTP 요청 (X-MEMBER-ID 헤더 포함)") HttpServletRequest httpServletRequest);
+            @Parameter(hidden = true) @RequestUserReferenceId String userReferenceId);
 }

--- a/user-service/src/main/java/club/gach_dong/config/UserReferenceIdParameterResolver.java
+++ b/user-service/src/main/java/club/gach_dong/config/UserReferenceIdParameterResolver.java
@@ -1,0 +1,33 @@
+package club.gach_dong.config;
+
+import test.user.annotation.RequestUserReferenceId;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserReferenceIdParameterResolver implements HandlerMethodArgumentResolver {
+
+    private static final String REFERENCE_ID_HEADER_KEY = "X-MEMBER-ID";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(RequestUserReferenceId.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String referenceId = request.getHeader(REFERENCE_ID_HEADER_KEY);
+
+        return referenceId != null ? referenceId : "";
+    }
+}

--- a/user-service/src/main/java/club/gach_dong/config/WebConfig.java
+++ b/user-service/src/main/java/club/gach_dong/config/WebConfig.java
@@ -1,0 +1,22 @@
+package club.gach_dong.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final club.gach_dong.config.UserReferenceIdParameterResolver userReferenceIdParameterResolver;
+
+    public WebConfig(club.gach_dong.config.UserReferenceIdParameterResolver userReferenceIdParameterResolver) {
+        this.userReferenceIdParameterResolver = userReferenceIdParameterResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userReferenceIdParameterResolver);
+    }
+}

--- a/user-service/src/main/java/club/gach_dong/controller/UserController.java
+++ b/user-service/src/main/java/club/gach_dong/controller/UserController.java
@@ -25,16 +25,16 @@ public class UserController implements UserApiSpecification {
             @Valid @ModelAttribute UserProfileRequest userProfileRequest,
             HttpServletRequest httpServletRequest) {
 
-        String userId = httpServletRequest.getHeader("X-MEMBER-ID");
+        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
 
-        if (userId == null || userId.isEmpty()) {
+        if (userReferenceId == null || userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
         try {
-            User user = userService.getOrCreateUser(userId);
+            User user = userService.getOrCreateUser(userReferenceId);
 
-            UserProfileResponse userProfileResponse = userService.saveProfileImage(userId, userProfileRequest.image());
+            UserProfileResponse userProfileResponse = userService.saveProfileImage(userReferenceId, userProfileRequest.image());
             return ResponseEntity.ok(userProfileResponse);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(null);
@@ -48,14 +48,14 @@ public class UserController implements UserApiSpecification {
             @Valid @ModelAttribute UserProfileRequest userProfileRequest,
             HttpServletRequest httpServletRequest) {
 
-        String userId = httpServletRequest.getHeader("X-MEMBER-ID");
+        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
 
-        if (userId == null || userId.isEmpty()) {
+        if (userReferenceId == null || userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
         try {
-            UserProfileResponse userProfileResponse = userService.updateProfileImage(userId, userProfileRequest.image());
+            UserProfileResponse userProfileResponse = userService.updateProfileImage(userReferenceId, userProfileRequest.image());
             return ResponseEntity.ok(userProfileResponse);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(null);
@@ -66,14 +66,14 @@ public class UserController implements UserApiSpecification {
 
     @Override
     public ResponseEntity<String> deleteProfileImage(HttpServletRequest httpServletRequest) {
-        String userId = httpServletRequest.getHeader("X-MEMBER-ID");
+        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
 
-        if (userId == null || userId.isEmpty()) {
+        if (userReferenceId == null || userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorStatus.USER_NOT_FOUND.getMessage());
         }
 
         try {
-            userService.deleteProfileImage(userId);
+            userService.deleteProfileImage(userReferenceId);
             return ResponseEntity.ok("이미지 삭제 성공");
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이미지 삭제 실패");
@@ -82,14 +82,14 @@ public class UserController implements UserApiSpecification {
 
     @Override
     public ResponseEntity<String> getProfileImage(HttpServletRequest httpServletRequest) {
-        String userId = httpServletRequest.getHeader("X-MEMBER-ID");
+        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
 
-        if (userId == null || userId.isEmpty()) {
+        if (userReferenceId == null || userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
         try {
-            String profileImageUrl = userService.getProfileImage(userId);
+            String profileImageUrl = userService.getProfileImage(userReferenceId);
             if (profileImageUrl == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body("프로필 이미지가 존재하지 않습니다.");
             }

--- a/user-service/src/main/java/club/gach_dong/controller/UserController.java
+++ b/user-service/src/main/java/club/gach_dong/controller/UserController.java
@@ -13,27 +13,23 @@ import club.gach_dong.entity.User;
 import club.gach_dong.service.UserService;
 import club.gach_dong.exception.ErrorStatus;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 @RestController
 @RequiredArgsConstructor
 public class UserController implements UserApiSpecification {
     private final UserService userService;
 
     @Override
+    @PostMapping(value = "/upload_profile_image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserProfileResponse> uploadProfileImage(
             @Valid @ModelAttribute UserProfileRequest userProfileRequest,
-            HttpServletRequest httpServletRequest) {
+            @club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
 
-        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
-
-        if (userReferenceId == null || userReferenceId.isEmpty()) {
+        if (userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
         try {
             User user = userService.getOrCreateUser(userReferenceId);
-
             UserProfileResponse userProfileResponse = userService.saveProfileImage(userReferenceId, userProfileRequest.image());
             return ResponseEntity.ok(userProfileResponse);
         } catch (IllegalArgumentException e) {
@@ -44,13 +40,12 @@ public class UserController implements UserApiSpecification {
     }
 
     @Override
+    @PostMapping(value = "/update_profile_image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserProfileResponse> updateProfileImage(
             @Valid @ModelAttribute UserProfileRequest userProfileRequest,
-            HttpServletRequest httpServletRequest) {
+            @club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
 
-        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
-
-        if (userReferenceId == null || userReferenceId.isEmpty()) {
+        if (userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 
@@ -65,10 +60,9 @@ public class UserController implements UserApiSpecification {
     }
 
     @Override
-    public ResponseEntity<String> deleteProfileImage(HttpServletRequest httpServletRequest) {
-        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
-
-        if (userReferenceId == null || userReferenceId.isEmpty()) {
+    @DeleteMapping("/delete_profile_image")
+    public ResponseEntity<String> deleteProfileImage(@club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
+        if (userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorStatus.USER_NOT_FOUND.getMessage());
         }
 
@@ -81,10 +75,9 @@ public class UserController implements UserApiSpecification {
     }
 
     @Override
-    public ResponseEntity<String> getProfileImage(HttpServletRequest httpServletRequest) {
-        String userReferenceId = httpServletRequest.getHeader("X-MEMBER-ID");
-
-        if (userReferenceId == null || userReferenceId.isEmpty()) {
+    @GetMapping("/profile_image")
+    public ResponseEntity<String> getProfileImage(@club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
+        if (userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
 

--- a/user-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
+++ b/user-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
@@ -9,9 +9,9 @@ public record UserProfileResponse(
         @NotNull
         Long id,
 
-        @Schema(description = "사용자 이메일", example = "user@gachon.ac.kr")
+        @Schema(description = "사용자 참조 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         @NotNull
-        String email,
+        String userReferenceId,
 
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/image.png")
         @NotNull
@@ -20,7 +20,7 @@ public record UserProfileResponse(
     public static UserProfileResponse from(User user) {
         return new UserProfileResponse(
                 user.getId(),
-                user.getEmail(),
+                user.getUserReferenceId(),
                 user.getProfileImageUrl()
         );
     }

--- a/user-service/src/main/java/club/gach_dong/entity/User.java
+++ b/user-service/src/main/java/club/gach_dong/entity/User.java
@@ -7,23 +7,23 @@ import lombok.NoArgsConstructor;
 @Entity
 @Data
 @NoArgsConstructor
-@Table(name = "user")
+@Table(name = "user_profileImage")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 255, nullable = false, unique = true)
-    private String email;
+    private String userReferenceId;
 
     private String profileImageUrl;
 
-    private User(String email, String profileImageUrl) {
-        this.email = email;
+    private User(String userReferenceId, String profileImageUrl) {
+        this.userReferenceId = userReferenceId;
         this.profileImageUrl = profileImageUrl;
     }
 
-    public static User of(String email, String profileImageUrl) {
-        return new User(email, profileImageUrl);
+    public static User of(String userReferenceId, String profileImageUrl) {
+        return new User(userReferenceId, profileImageUrl);
     }
 }

--- a/user-service/src/main/java/club/gach_dong/entity/User.java
+++ b/user-service/src/main/java/club/gach_dong/entity/User.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Data
 @NoArgsConstructor
-@Table(name = "user_profileImage")
+@Table(name = "user")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/user-service/src/main/java/club/gach_dong/repository/UserRepository.java
+++ b/user-service/src/main/java/club/gach_dong/repository/UserRepository.java
@@ -1,9 +1,10 @@
 package club.gach_dong.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import club.gach_dong.entity.User;
+import test.user.entity.User;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByUserReferenceId(String userReferenceId);
+
 }

--- a/user-service/src/main/java/club/gach_dong/service/UserService.java
+++ b/user-service/src/main/java/club/gach_dong/service/UserService.java
@@ -59,9 +59,9 @@ public class UserService {
         return "";
     }
 
-    private String saveImageFile(String email, MultipartFile image) throws IOException {
+    private String saveImageFile(String userReferenceId, MultipartFile image) throws IOException {
         String uuid = UUID.randomUUID().toString();
-        String fileName = email + "_" + uuid + "_" + image.getOriginalFilename();
+        String fileName = userReferenceId + "_" + uuid + "_" + image.getOriginalFilename();
         InputStream inputStream = image.getInputStream();
 
         BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, fileName))
@@ -80,14 +80,14 @@ public class UserService {
     }
 
     @Transactional
-    public UserProfileResponse saveProfileImage(String email, MultipartFile image) {
+    public UserProfileResponse saveProfileImage(String userReferenceId, MultipartFile image) {
         validateImage(image);
 
         try {
-            String imageUrl = saveImageFile(email, image);
+            String imageUrl = saveImageFile(userReferenceId, image);
 
-            User user = userRepository.findByEmail(email)
-                    .orElseGet(() -> User.of(email, null));
+            User user = userRepository.findByUserReferenceId(userReferenceId)
+                    .orElseGet(() -> User.of(userReferenceId, null));
             user.setProfileImageUrl(imageUrl);
             userRepository.save(user);
 
@@ -98,15 +98,15 @@ public class UserService {
     }
 
     @Transactional
-    public UserProfileResponse updateProfileImage(String email, MultipartFile image) {
+    public UserProfileResponse updateProfileImage(String userReferenceId, MultipartFile image) {
         validateImage(image);
 
         try {
-            User user = userRepository.findByEmail(email)
+            User user = userRepository.findByUserReferenceId(userReferenceId)
                     .orElseThrow(() -> new RuntimeException(ErrorStatus.USER_NOT_FOUND.getMessage()));
             deleteOldImage(user);
 
-            String imageUrl = saveImageFile(email, image);
+            String imageUrl = saveImageFile(userReferenceId, image);
 
             user.setProfileImageUrl(imageUrl);
             userRepository.save(user);
@@ -118,8 +118,8 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteProfileImage(String email) {
-        User user = userRepository.findByEmail(email)
+    public void deleteProfileImage(String userReferenceId) {
+        User user = userRepository.findByUserReferenceId(userReferenceId)
                 .orElseThrow(() -> new RuntimeException(ErrorStatus.USER_NOT_FOUND.getMessage()));
 
         try {
@@ -131,14 +131,14 @@ public class UserService {
         }
     }
 
-    public String getProfileImage(String email) {
-        User user = userRepository.findByEmail(email)
+    public String getProfileImage(String userReferenceId) {
+        User user = userRepository.findByUserReferenceId(userReferenceId)
                 .orElseThrow(() -> new RuntimeException(ErrorStatus.USER_NOT_FOUND.getMessage()));
         return user.getProfileImageUrl();
     }
 
-    public User getOrCreateUser(String email) {
-        return userRepository.findByEmail(email)
-                .orElseGet(() -> User.of(email, null));
+    public User getOrCreateUser(String userReferenceId) {
+        return userRepository.findByUserReferenceId(userReferenceId)
+                .orElseGet(() -> User.of(userReferenceId, null));
     }
 }


### PR DESCRIPTION
## 1. 관련 이슈

#63 

## 2. 구현한 내용 또는 수정한 내용

user 엔티티의 userId를 받아오는 부분인 email 필드를 user_reference_id로 수정합니다.

## 3. TODO
- [x] User 엔티티의 필드 email -> userReferenceId 수정
- [x] UserProfileResponse의 필드 email -> userReferenceId 수정
- [x] UserService, UserController에 적용

## 4. 배포 전 Checklist
@EeeasyCode
로컬 테스트 완료했습니다.