### PR TITLE
[FIX] user-service REFERENCE_ID_HEADER_KEY 값 수정 및 controller mapping 삭제

### DIFF
--- a/user-service/src/main/java/club/gach_dong/config/UserReferenceIdParameterResolver.java
+++ b/user-service/src/main/java/club/gach_dong/config/UserReferenceIdParameterResolver.java
@@ -12,7 +12,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 public class UserReferenceIdParameterResolver implements HandlerMethodArgumentResolver {
 
-    private static final String REFERENCE_ID_HEADER_KEY = "X-MEMBER-ID";
+    private static final String REFERENCE_ID_HEADER_KEY = "X-USER-MEMBER-ID";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {

--- a/user-service/src/main/java/club/gach_dong/controller/UserController.java
+++ b/user-service/src/main/java/club/gach_dong/controller/UserController.java
@@ -19,7 +19,6 @@ public class UserController implements UserApiSpecification {
     private final UserService userService;
 
     @Override
-    @PostMapping(value = "/upload_profile_image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserProfileResponse> uploadProfileImage(
             @Valid @ModelAttribute UserProfileRequest userProfileRequest,
             @club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
@@ -40,7 +39,6 @@ public class UserController implements UserApiSpecification {
     }
 
     @Override
-    @PostMapping(value = "/update_profile_image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<UserProfileResponse> updateProfileImage(
             @Valid @ModelAttribute UserProfileRequest userProfileRequest,
             @club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
@@ -60,7 +58,6 @@ public class UserController implements UserApiSpecification {
     }
 
     @Override
-    @DeleteMapping("/delete_profile_image")
     public ResponseEntity<String> deleteProfileImage(@club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
         if (userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorStatus.USER_NOT_FOUND.getMessage());
@@ -75,7 +72,6 @@ public class UserController implements UserApiSpecification {
     }
 
     @Override
-    @GetMapping("/profile_image")
     public ResponseEntity<String> getProfileImage(@club.gach_dong.annotation.RequestUserReferenceId String userReferenceId) {
         if (userReferenceId.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);


### PR DESCRIPTION
## 1. 관련 이슈

#76 

## 2. 구현한 내용 또는 수정한 내용

- REFERENCE_ID_HEADER_KEY 값을 "X-USER-MEMBER-ID"로 수정합니다.
- UserController의 Mapping을 제거합니다.

## 3. TODO
- [x] REFERENCE_ID_HEADER_KEY 값을 "X-MEMBER-ID"에서 "X-USER-MEMBER-ID"로 수정
- [x] UserController의 Mapping 제거

## 4. 배포 전 Checklist
@EeeasyCode 