### PR TITLE
[FIX] Application Domain, User와 Admin용 API 분리

### DIFF
--- a/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
@@ -1,0 +1,58 @@
+package club.gach_dong.api;
+
+import club.gach_dong.dto.request.ApplicationRequestDTO;
+import club.gach_dong.dto.response.ApplicationResponseDTO;
+import club.gach_dong.response.ResForm;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "지원 API(관리자)", description = "동아리 지원 관련 관리자용 API")
+@RestController
+@RequestMapping("/api/v1/admin")
+@Validated
+public interface ApplicationAdminApiSpecification {
+
+    @Operation(summary = "관리자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @GetMapping("/admin/form/{formId}")
+    ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long formId,
+                                                                           HttpServletRequest httpServletRequest);
+
+    @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @PostMapping("/admin/form/create")
+    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
+            @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+            HttpServletRequest httpServletRequest);
+
+    @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @PutMapping("/admin/form/{form_id}")
+    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(
+            @PathVariable("form_id") Long formId,
+            @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+            HttpServletRequest httpServletRequest);
+
+    @Operation(summary = "지원 양식 삭제 API", description = "지원서 양식 ID를 이용해 양식을 삭제합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @DeleteMapping("/admin/form/{formId}")
+    ResForm<?> deleteApplicationForm(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
+
+    @Operation(summary = "사용자 지원 상태 변경 API", description = "지원 ID를 이용해 지원 상태를 변경합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @PutMapping("/status")
+    ResForm<?> changeApplicationStatus(
+            @Valid @RequestBody ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
+            HttpServletRequest httpServletRequest);
+
+    @Operation(summary = "지원 목록 조회 API", description = "지원 ID를 이용해 지원 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @GetMapping("/{applyId}")
+    ResForm<?> getClubApplicationList(@PathVariable("applyId") Long applyId, HttpServletRequest httpServletRequest);
+}

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
@@ -25,25 +25,25 @@ import org.springframework.web.bind.annotation.RestController;
 public interface ApplicationAdminApiSpecification {
 
     @Operation(summary = "관리자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
-    @GetMapping("/admin/form/{formId}")
+    @GetMapping("/form/{formId}")
     ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long formId,
                                                                            HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.", security = @SecurityRequirement(name = "Authorization"))
-    @PostMapping("/admin/form/create")
+    @PostMapping("/form/create")
     ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
             @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
             HttpServletRequest httpServletRequest);
 
     @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.", security = @SecurityRequirement(name = "Authorization"))
-    @PutMapping("/admin/form/{form_id}")
+    @PutMapping("/form/{form_id}")
     ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(
             @PathVariable("form_id") Long formId,
             @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
             HttpServletRequest httpServletRequest);
 
     @Operation(summary = "지원 양식 삭제 API", description = "지원서 양식 ID를 이용해 양식을 삭제합니다.", security = @SecurityRequirement(name = "Authorization"))
-    @DeleteMapping("/admin/form/{formId}")
+    @DeleteMapping("/form/{formId}")
     ResForm<?> deleteApplicationForm(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
 
     @Operation(summary = "사용자 지원 상태 변경 API", description = "지원 ID를 이용해 지원 상태를 변경합니다.", security = @SecurityRequirement(name = "Authorization"))

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -5,6 +5,7 @@ import club.gach_dong.dto.response.ApplicationResponseDTO;
 import club.gach_dong.response.ResForm;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -16,40 +17,28 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "지원 API", description = "동아리 지원 관련 API")
+@Tag(name = "지원 API(사용자)", description = "동아리 지원 관련 사용자용 API")
 @RestController
 @RequestMapping("/api/v1")
 @Validated
 public interface ApplicationApiSpecification {
 
-    @Operation(summary = "관리자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.", security = @SecurityRequirement(name = "Authorization")
-    @GetMapping("/admin/form/{formId}")
-    ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(@PathVariable("formId") Long formId,
-                                                                           HttpServletRequest httpServletRequest);
-
-    @Operation(summary = "사용자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.", security = @SecurityRequirement(name = "Authorization")
+    @Operation(summary = "사용자용 지원서 양식 조회 API", description = "지원서 양식 ID를 이용해 양식을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("/form/{formId}")
     ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(@PathVariable("formId") Long formId,
                                                                          HttpServletRequest httpServletRequest);
 
-    @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization")
+    @Operation(summary = "사용자 지원 내역 목록 조회 API", description = "지원 내역 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("/list")
     ResForm<ApplicationResponseDTO.ToGetApplicationHistoryListDTO> getApplicationHistory(
             HttpServletRequest httpServletRequest);
 
-    @Operation(summary = "동아리 지원서 양식 생성 요청 API", description = "동아리 지원서 양식을 생성합니다.", security = @SecurityRequirement(name = "Authorization")
-    @PostMapping("/admin/form/create")
-    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
-            @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
-            HttpServletRequest httpServletRequest);
-
-    @Operation(summary = "동아리 지원 API", description = "동아리에 지원합니다.", security = @SecurityRequirement(name = "Authorization")
+    @Operation(summary = "동아리 지원 API", description = "동아리에 지원합니다.", security = @SecurityRequirement(name = "Authorization"))
     @PostMapping(value = "/{apply_id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(
             @PathVariable("apply_id") Long applyId,
@@ -58,14 +47,7 @@ public interface ApplicationApiSpecification {
             HttpServletRequest httpServletRequest
     );
 
-    @Operation(summary = "동아리 지원서 양식 수정 요청 API", description = "동아리 지원서 양식을 수정합니다.", security = @SecurityRequirement(name = "Authorization")
-    @PutMapping("/admin/form/{form_id}")
-    ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(
-            @PathVariable("form_id") Long formId,
-            @Valid @RequestBody ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
-            HttpServletRequest httpServletRequest);
-
-    @Operation(summary = "동아리 지원 수정 API", description = "동아리에 지원을 수정합니다.", security = @SecurityRequirement(name = "Authorization")
+    @Operation(summary = "동아리 지원 수정 API", description = "동아리에 지원을 수정합니다.", security = @SecurityRequirement(name = "Authorization"))
     @PutMapping(value = "/{apply_id} ", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> changeApplication(
             @PathVariable("apply_id") Long applyId,
@@ -73,23 +55,9 @@ public interface ApplicationApiSpecification {
             @RequestPart(value = "toApplyClub", required = true) @Parameter(description = "동아리 지원에 필요한 요청 데이터") @Valid ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
             HttpServletRequest httpServletRequest);
 
-    @Operation(summary = "지원 양식 삭제 API", description = "지원서 양식 ID를 이용해 양식을 삭제합니다.", security = @SecurityRequirement(name = "Authorization")
-    @DeleteMapping("/admin/form/{formId}")
-    ResForm<?> deleteApplicationForm(@PathVariable("formId") Long formId, HttpServletRequest httpServletRequest);
-
-    @Operation(summary = "사용자 지원 취소 API", description = "지원 ID를 이용해 지원을 취소합니다.", security = @SecurityRequirement(name = "Authorization")
+    @Operation(summary = "사용자 지원 취소 API", description = "지원 ID를 이용해 지원을 취소합니다.", security = @SecurityRequirement(name = "Authorization"))
     @DeleteMapping("/apply/{applyId}")
     ResForm<?> deleteApplication(@PathVariable("applyId") Long applyId, HttpServletRequest httpServletRequest);
-
-    @Operation(summary = "사용자 지원 상태 변경 API", description = "지원 ID를 이용해 지원 상태를 변경합니다.", security = @SecurityRequirement(name = "Authorization")
-    @PutMapping("/status")
-    ResForm<?> changeApplicationStatus(
-            @Valid @RequestBody ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
-            HttpServletRequest httpServletRequest);
-
-    @Operation(summary = "지원 목록 조회 API", description = "지원 ID를 이용해 지원 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization")
-    @GetMapping("/admin/{applyId}")
-    ResForm<?> getClubApplicationList(@PathVariable("applyId") Long applyId, HttpServletRequest httpServletRequest);
 
 //    @Operation(summary = "지원 상세 조회 API", description = "지원 ID를 이용해 지원 내역을 조회합니다.")
 //    @DeleteMapping("/admin/{applicationId}")

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationAdminController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationAdminController.java
@@ -1,0 +1,76 @@
+package club.gach_dong.controller;
+
+import club.gach_dong.api.ApplicationAdminApiSpecification;
+import club.gach_dong.dto.request.ApplicationRequestDTO;
+import club.gach_dong.dto.response.ApplicationResponseDTO;
+import club.gach_dong.response.ResForm;
+import club.gach_dong.response.status.InSuccess;
+import club.gach_dong.service.ApplicationService;
+import club.gach_dong.service.AuthorizationService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ApplicationAdminController implements ApplicationAdminApiSpecification {
+
+
+    public final ApplicationService applicationService;
+    public final AuthorizationService authorizationService;
+
+    @Override
+    public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId,
+                                                                                  HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId,
+                userId);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_ADMIN_INFO, toGetFormInfoAdminDTO);
+    }
+
+    @Override
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
+            ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO,
+            HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(
+                createApplicationFormDTO, userId);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CREATED, toCreateApplicationFormDTO);
+    }
+
+    @Override
+    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId,
+                                                                                            ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
+                                                                                            HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(
+                formId, toCreateApplicationFormDTO, userId);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
+    }
+
+    @Override
+    public ResForm<?> deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+        applicationService.deleteApplicationForm(formId, userId);
+        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_DELETED, null);
+    }
+
+    @Override
+    public ResForm<?> changeApplicationStatus(ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
+                                              HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+        applicationService.changeApplicationStatus(userId, toChangeApplicationStatus);
+        return ResForm.onSuccess(InSuccess.APPLICATION_STATUS_CHANGED, null);
+    }
+
+    @Override
+    public ResForm<ApplicationResponseDTO.ToGetApplicationListAdminDTO> getClubApplicationList(Long applyId,
+                                                                                               HttpServletRequest httpServletRequest) {
+        String userId = authorizationService.getUserId(httpServletRequest);
+
+        ApplicationResponseDTO.ToGetApplicationListAdminDTO toGetApplicationListAdminDTO = applicationService.getApplicationListAdmin(
+                userId, applyId);
+
+        return ResForm.onSuccess(InSuccess._OK, toGetApplicationListAdminDTO);
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -21,15 +21,6 @@ public class ApplicationController implements ApplicationApiSpecification {
     public final AuthorizationService authorizationService;
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToGetFormInfoAdminDTO> getFormInfoAdmin(Long formId,
-                                                                                  HttpServletRequest httpServletRequest) {
-        String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToGetFormInfoAdminDTO toGetFormInfoAdminDTO = applicationService.getFormInfoAdmin(formId,
-                userId);
-        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_GET_ADMIN_INFO, toGetFormInfoAdminDTO);
-    }
-
-    @Override
     public ResForm<ApplicationResponseDTO.ToGetFormInfoUserDTO> getFormInfoUser(Long formId,
                                                                                 HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
@@ -48,16 +39,6 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> createApplicationForm(
-            ApplicationRequestDTO.ToCreateApplicationFormDTO createApplicationFormDTO,
-            HttpServletRequest httpServletRequest) {
-        String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO = applicationService.createApplicationForm(
-                createApplicationFormDTO, userId);
-        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CREATED, toCreateApplicationFormDTO);
-    }
-
-    @Override
     public ResForm<ApplicationResponseDTO.ToCreateApplicationDTO> createApplication(Long applyId,
                                                                                     List<MultipartFile> files,
                                                                                     ApplicationRequestDTO.ToApplyClubDTO toApplyClub,
@@ -66,16 +47,6 @@ public class ApplicationController implements ApplicationApiSpecification {
         ApplicationResponseDTO.ToCreateApplicationDTO toCreateApplicationDTO = applicationService.createApplication(
                 applyId, files, toApplyClub, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_SUCCESS, toCreateApplicationDTO);
-    }
-
-    @Override
-    public ResForm<ApplicationResponseDTO.ToCreateApplicationFormDTO> changeApplicationForm(Long formId,
-                                                                                            ApplicationRequestDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO,
-                                                                                            HttpServletRequest httpServletRequest) {
-        String userId = authorizationService.getUserId(httpServletRequest);
-        ApplicationResponseDTO.ToCreateApplicationFormDTO toCreateApplicationFormDTO1 = applicationService.changeApplicationForm(
-                formId, toCreateApplicationFormDTO, userId);
-        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_CHANGED, toCreateApplicationFormDTO1);
     }
 
     @Override
@@ -90,36 +61,10 @@ public class ApplicationController implements ApplicationApiSpecification {
     }
 
     @Override
-    public ResForm<?> deleteApplicationForm(Long formId, HttpServletRequest httpServletRequest) {
-        String userId = authorizationService.getUserId(httpServletRequest);
-        applicationService.deleteApplicationForm(formId, userId);
-        return ResForm.onSuccess(InSuccess.APPLICATION_FORM_DELETED, null);
-    }
-
-    @Override
     public ResForm<?> deleteApplication(Long applyId, HttpServletRequest httpServletRequest) {
         String userId = authorizationService.getUserId(httpServletRequest);
         applicationService.deleteApplication(applyId, userId);
         return ResForm.onSuccess(InSuccess.APPLICATION_DELETED, null);
-    }
-
-    @Override
-    public ResForm<?> changeApplicationStatus(ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
-                                              HttpServletRequest httpServletRequest) {
-        String userId = authorizationService.getUserId(httpServletRequest);
-        applicationService.changeApplicationStatus(userId, toChangeApplicationStatus);
-        return ResForm.onSuccess(InSuccess.APPLICATION_STATUS_CHANGED, null);
-    }
-
-    @Override
-    public ResForm<ApplicationResponseDTO.ToGetApplicationListAdminDTO> getClubApplicationList(Long applyId,
-                                                                                               HttpServletRequest httpServletRequest) {
-        String userId = authorizationService.getUserId(httpServletRequest);
-
-        ApplicationResponseDTO.ToGetApplicationListAdminDTO toGetApplicationListAdminDTO = applicationService.getApplicationListAdmin(
-                userId, applyId);
-
-        return ResForm.onSuccess(InSuccess._OK, toGetApplicationListAdminDTO);
     }
 
 //    @Override

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -154,6 +154,9 @@ public class ApplicationService {
             }
         }
 
+        ApplicationForm applicationForm = applicationFormRepository.findById(toApplyClub.getApplicationFormId())
+                .orElseThrow(() -> new CustomException(ErrorStatus.APPLICATION_FORM_NOT_FOUND));
+
         if (files != null) {
             //업로드 할 파일 검증 (길이, 확장자 등)
             fileService.validateFiles(files);
@@ -301,7 +304,7 @@ public class ApplicationService {
         if (applicationList.isEmpty()) {
             throw new CustomException(ErrorStatus.APPLICATION_NOT_PRESENT);
         }
-        
+
         List<ApplicationResponseDTO.ToGetApplicationDTO> toGetApplicationDTOs = applicationList.stream()
                 .map(application -> ApplicationResponseDTO.ToGetApplicationDTO.builder()
                         .applicationId(application.getId())

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -18,7 +18,7 @@ public class AuthorizationService {
     @Value("${msa.url.club}")
     private String clubUrl;
 
-    private final static String MEMBER_ID_HEADER_KEY = "X-MEMBER-ID";
+    private final static String MEMBER_ID_HEADER_KEY = "X-USER-REFERENCE-ID";
 
     public final RestClient restClient;
 


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/71

## 2. 구현한 내용 또는 수정한 내용

User와 Admin용 API를 Controller 단에서 분리했습니다.
'+ 예외 추가, Header 임시 대응

### <나중에 추가할 내용>
유효한 지원인지 확인하는 부분(Club API 완성 후 제작 예정)
Response 구조(Success, Error) 일원화
Header 관련 부분

## 3. TODO

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->