### PR TITLE
[FEAT] auth-service 회원가입용 인증 코드 발송 api 추가

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/api/PublicAdminAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/PublicAdminAuthApiSpecification.java
@@ -15,6 +15,11 @@ import club.gach_dong.dto.response.AuthResponse;
 @RequestMapping("/public/admin/api/v1")
 public interface PublicAdminAuthApiSpecification {
 
+    @Operation(summary = "회원가입용 인증 코드 발송", description = "이메일로 회원가입을 위한 유효시간 3분의 6자리의 인증 코드를 발송합니다.")
+    @PostMapping("/send-registration-verification-code")
+    ResponseEntity<String> sendRegistrationVerificationCode(
+            @Parameter(description = "회원가입을 위한 이메일 주소") @RequestParam String email);
+
     @Operation(summary = "회원가입", description = "회원가입을 완료합니다. \n" +
             "- email: 사용자 이메일 (gachon.ac.kr 도메인) \n" +
             "- password: 8~16자 영문, 숫자, 특수문자를 포함한 비밀번호 \n" +

--- a/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
@@ -20,6 +20,11 @@ public interface PublicAuthApiSpecification {
     ResponseEntity<String> sendVerificationCode(
             @Parameter(description = "사용자의 이메일 주소") @RequestParam String email);
 
+    @Operation(summary = "회원가입용 인증 코드 발송", description = "이메일로 회원가입을 위한 유효시간 3분의 6자리의 인증 코드를 발송합니다.")
+    @PostMapping("/send-registration-verification-code")
+    ResponseEntity<String> sendRegistrationVerificationCode(
+            @Parameter(description = "회원가입을 위한 이메일 주소") @RequestParam String email);
+
     @Operation(summary = "회원가입", description = "회원가입을 완료합니다. \n" +
             "- email: 사용자 이메일 (gachon.ac.kr 도메인) \n" +
             "- password: 8~16자 영문, 숫자, 특수문자를 포함한 비밀번호 \n" +

--- a/auth-service/src/main/java/club/gach_dong/controller/PublicAdminAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/PublicAdminAuthController.java
@@ -21,6 +21,16 @@ public class PublicAdminAuthController implements PublicAdminAuthApiSpecificatio
     private final JwtUtil jwtUtil;
 
     @Override
+    public ResponseEntity<String> sendRegistrationVerificationCode(@RequestParam String email) {
+        try {
+            adminService.sendRegistrationVerificationCode(email);
+            return ResponseEntity.ok("회원가입용 인증 코드가 이메일로 발송되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("회원가입용 인증 코드 발송 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
     public ResponseEntity<String> completeRegistration(@Valid @RequestBody RegistrationRequest registrationRequest) {
         try {
             adminService.completeRegistration(registrationRequest);

--- a/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
@@ -41,6 +41,16 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
+    public ResponseEntity<String> sendRegistrationVerificationCode(@RequestParam String email) {
+        try {
+            userService.sendRegistrationVerificationCode(email);
+            return ResponseEntity.ok("회원가입용 인증 코드가 이메일로 발송되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("인증 코드 발송 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
         User user = userService.findByEmail(loginRequest.email());
 

--- a/auth-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -46,6 +46,10 @@ public class AdminService {
 
     public void sendRegistrationVerificationCode(String email) {
         try {
+            if (!isValidEmail(email)) {
+                throw new RuntimeException("이메일은 gachon.ac.kr 도메인이어야 합니다.");
+            }
+
             if (adminRepository.findByEmail(email).isPresent()) {
                 throw new RuntimeException("이미 등록된 이메일입니다. 인증 코드를 발송할 수 없습니다.");
             }
@@ -132,6 +136,10 @@ public class AdminService {
 
     public String encodePassword(String password) {
         return passwordEncoder.encode(password);
+    }
+
+    private boolean isValidEmail(String email) {
+        return email != null && email.matches("^[a-zA-Z0-9._%+-]+@gachon\\.ac\\.kr$");
     }
 
     public void blacklistToken(String token) {

--- a/auth-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -7,7 +7,6 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import club.gach_dong.entity.Admin;
-import club.gach_dong.entity.User;
 import club.gach_dong.repository.AdminRepository;
 import club.gach_dong.util.JwtUtil;
 import club.gach_dong.dto.request.RegistrationRequest;
@@ -43,6 +42,34 @@ public class AdminService {
         } else {
             throw new RuntimeException("유효하지 않거나 만료된 인증 코드입니다.");
         }
+    }
+
+    public void sendRegistrationVerificationCode(String email) {
+        try {
+            if (adminRepository.findByEmail(email).isPresent()) {
+                throw new RuntimeException("이미 등록된 이메일입니다. 인증 코드를 발송할 수 없습니다.");
+            }
+
+            String code = generateVerificationCode();
+            redisTemplate.opsForValue().set(email, code, 3, TimeUnit.MINUTES);
+            sendVerificationEmail(email, code);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("인증 코드 발송 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    private String generateVerificationCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+
+    private void sendVerificationEmail(String email, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("회원가입 인증 코드");
+        message.setText("안녕하세요! 아래의 인증 코드를 입력하여 회원가입을 완료해주세요:\n\n" + code);
+        mailSender.send(message);
     }
 
     public void completeRegistration(RegistrationRequest registrationRequest) {
@@ -110,5 +137,4 @@ public class AdminService {
     public void blacklistToken(String token) {
         jwtUtil.blacklistAdminToken(token);
     }
-
 }

--- a/auth-service/src/main/java/club/gach_dong/service/UserService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/UserService.java
@@ -52,6 +52,25 @@ public class UserService {
         }
     }
 
+    public void sendRegistrationVerificationCode(String email) {
+        try {
+            if (!isValidEmail(email)) {
+                throw new RuntimeException("이메일은 gachon.ac.kr 도메인이어야 합니다.");
+            }
+
+            if (userRepository.findByEmail(email).isPresent()) {
+                throw new RuntimeException("이미 등록된 이메일입니다.");
+            }
+
+            String code = generateVerificationCode();
+            redisTemplate.opsForValue().set(email, code, 3, TimeUnit.MINUTES);
+            sendVerificationEmail(email, code);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("인증 코드 발송 중 오류 발생: " + e.getMessage());
+        }
+    }
+
     private String generateVerificationCode() {
         Random random = new Random();
         return String.format("%06d", random.nextInt(1000000));
@@ -144,5 +163,4 @@ public class UserService {
     public void blacklistToken(String token) {
         jwtUtil.blacklistUserToken(token);
     }
-
 }


### PR DESCRIPTION
## 1. 관련 이슈

#80 

## 2. 구현한 내용 또는 수정한 내용

회원가입용 인증 코드 발송 api를 추가합니다.
해당 api는 기존 인증 코드 발송 api와는 다르게 이미 가입된 사용자에 대한 처리가 추가되었습니다.

## 3. TODO
- [ ] /send-registration-verification-code 추가 (사용자)
- [ ] /send-registration-verification-code 추가 (관리자)

## 4. 배포 전 Checklist
@EeeasyCode 