### PR TITLE
[FEAT] user-service와의 통신으로 프로필 이미지 조회 api에 profileImageUrl 추가

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/config/RestTemplateConfig.java
+++ b/auth-service/src/main/java/club/gach_dong/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package club.gach_dong.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/auth-service/src/main/java/club/gach_dong/controller/AdminAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AdminAuthController.java
@@ -9,6 +9,7 @@ import club.gach_dong.api.AdminAuthApiSpecification;
 import club.gach_dong.dto.request.ChangePasswordRequest;
 import club.gach_dong.dto.response.UserProfileResponse;
 import club.gach_dong.entity.Admin;
+import club.gach_dong.entity.User;
 import club.gach_dong.service.AdminService;
 import club.gach_dong.util.JwtUtil;
 
@@ -75,11 +76,17 @@ public class AdminAuthController implements AdminAuthApiSpecification {
         }
 
         try {
-            String email = jwtUtil.getAdminEmailFromToken(token);
-            Admin admin = adminService.findByEmail(email);
+            String userReferenceId = jwtUtil.getAdminReferenceIdFromToken(token);
+
+            Admin admin = adminService.findByUserReferenceId(userReferenceId);
             if (admin == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
             }
+
+            String profileImageUrl = adminService.getProfileImageUrl(userReferenceId);
+
+            admin.setProfileImageUrl(profileImageUrl);
+            adminService.updateAdminProfileImage(admin);
 
             UserProfileResponse userProfileResponse = UserProfileResponse.from(admin);
             return ResponseEntity.ok(userProfileResponse);
@@ -87,5 +94,4 @@ public class AdminAuthController implements AdminAuthApiSpecification {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
     }
-
 }

--- a/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
@@ -75,11 +75,17 @@ public class AuthController implements AuthApiSpecification {
         }
 
         try {
-            String email = jwtUtil.getUserEmailFromToken(token);
-            User user = userService.findByEmail(email);
+            String userReferenceId = jwtUtil.getUserReferenceIdFromToken(token);
+
+            User user = userService.findByUserReferenceId(userReferenceId);
             if (user == null) {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
             }
+
+            String profileImageUrl = userService.getProfileImageUrl(userReferenceId);
+
+            user.setProfileImageUrl(profileImageUrl);
+            userService.updateUserProfileImage(user);
 
             UserProfileResponse userProfileResponse = UserProfileResponse.from(user);
             return ResponseEntity.ok(userProfileResponse);
@@ -87,5 +93,4 @@ public class AuthController implements AuthApiSpecification {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
     }
-
 }

--- a/auth-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
@@ -12,13 +12,17 @@ public record UserProfileResponse(
         String name,
 
         @Schema(description = "사용자 권한", example = "USER, ADMIN")
-        String role
+        String role,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
+        String profileImageUrl
 ) {
     public static UserProfileResponse from(User user) {
         return new UserProfileResponse(
                 user.getEmail(),
                 user.getName(),
-                user.getRole().name()
+                user.getRole().name(),
+                user.getProfileImageUrl()
         );
     }
 
@@ -26,7 +30,8 @@ public record UserProfileResponse(
         return new UserProfileResponse(
                 admin.getEmail(),
                 admin.getName(),
-                admin.getRole().name()
+                admin.getRole().name(),
+                admin.getProfileImageUrl()
         );
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/entity/Admin.java
+++ b/auth-service/src/main/java/club/gach_dong/entity/Admin.java
@@ -16,7 +16,7 @@ public class Admin {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private UUID user_reference_id;
+    private String userReferenceId;
 
     @Column(length = 255, nullable = false, unique = true)
     private String email;
@@ -33,16 +33,20 @@ public class Admin {
 
     private boolean enabled;
 
-    private Admin(UUID user_reference_id, String email, String password, String name, Role role, boolean enabled) {
-        this.user_reference_id = user_reference_id;
+    @Column(length = 255)
+    private String profileImageUrl;
+
+    private Admin(String userReferenceId, String email, String password, String name, Role role, boolean enabled, String profileImageUrl) {
+        this.userReferenceId = userReferenceId;
         this.email = email;
         this.password = password;
         this.name = name;
         this.role = role;
         this.enabled = enabled;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public static Admin of(String email, String password, String name, Role role) {
-        return new Admin(UUID.randomUUID(), email, password, name, role, true);
+        return new Admin(UUID.randomUUID().toString(), email, password, name, role, true, null);
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/entity/User.java
+++ b/auth-service/src/main/java/club/gach_dong/entity/User.java
@@ -16,7 +16,7 @@ public class User {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private UUID user_reference_id;
+    private String userReferenceId;
 
     @Column(length = 255, nullable = false, unique = true)
     private String email;
@@ -33,16 +33,20 @@ public class User {
 
     private boolean enabled;
 
-    private User(UUID user_reference_id, String email, String password, String name, Role role, boolean enabled) {
-        this.user_reference_id = user_reference_id;
+    @Column(length = 255)
+    private String profileImageUrl;
+
+    private User(String userReferenceId, String email, String password, String name, Role role, boolean enabled, String profileImageUrl) {
+        this.userReferenceId = userReferenceId;
         this.email = email;
         this.password = password;
         this.name = name;
         this.role = role;
         this.enabled = enabled;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public static User of(String email, String password, String name, Role role) {
-        return new User(UUID.randomUUID(), email, password, name, role, true);
+        return new User(UUID.randomUUID().toString(), email, password, name, role, true, null);
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/repository/AdminRepository.java
+++ b/auth-service/src/main/java/club/gach_dong/repository/AdminRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
     Optional<Admin> findByEmail(String email);
+    Optional<Admin> findByUserReferenceId(String userReferenceId);
 }

--- a/auth-service/src/main/java/club/gach_dong/repository/UserRepository.java
+++ b/auth-service/src/main/java/club/gach_dong/repository/UserRepository.java
@@ -1,12 +1,11 @@
 package club.gach_dong.repository;
 
-import club.gach_dong.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import club.gach_dong.entity.User;
 
 import java.util.Optional;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByUserReferenceId(String userReferenceId);
 }

--- a/auth-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -1,12 +1,15 @@
 package club.gach_dong.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import club.gach_dong.entity.Admin;
+import club.gach_dong.entity.User;
 import club.gach_dong.repository.AdminRepository;
 import club.gach_dong.util.JwtUtil;
 import club.gach_dong.dto.request.RegistrationRequest;
@@ -31,6 +34,12 @@ public class AdminService {
 
     @Autowired
     private JwtUtil jwtUtil;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${user.service.url}")
+    private String userServiceUrl;
 
     private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int PASSWORD_LENGTH = 8;
@@ -144,5 +153,26 @@ public class AdminService {
 
     public void blacklistToken(String token) {
         jwtUtil.blacklistAdminToken(token);
+    }
+
+    public String getProfileImageUrl(String userReferenceId) {
+        String url = userServiceUrl + userReferenceId;
+
+
+        try {
+            String profileImageUrl = restTemplate.getForObject(url, String.class);
+
+            return profileImageUrl != null ? profileImageUrl : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+    public Admin findByUserReferenceId(String userReferenceId) {
+        return adminRepository.findByUserReferenceId(userReferenceId)
+                .orElse(null);
+    }
+
+    public void updateAdminProfileImage(Admin admin) {
+        adminRepository.save(admin);
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/service/UserService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/UserService.java
@@ -1,11 +1,13 @@
 package club.gach_dong.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import club.gach_dong.entity.Role;
 import club.gach_dong.entity.User;
 import club.gach_dong.repository.UserRepository;
@@ -13,7 +15,9 @@ import club.gach_dong.util.JwtUtil;
 import club.gach_dong.dto.request.RegistrationRequest;
 import club.gach_dong.dto.request.ChangePasswordRequest;
 
+import java.util.Optional;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -33,6 +37,12 @@ public class UserService {
 
     @Autowired
     private JwtUtil jwtUtil;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${user.service.url}")
+    private String userServiceUrl;
 
     private static final String CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int PASSWORD_LENGTH = 8;
@@ -162,5 +172,25 @@ public class UserService {
 
     public void blacklistToken(String token) {
         jwtUtil.blacklistUserToken(token);
+    }
+
+    public String getProfileImageUrl(String userReferenceId) {
+        String url = userServiceUrl + userReferenceId;
+
+        try {
+            String profileImageUrl = restTemplate.getForObject(url, String.class);
+
+            return profileImageUrl != null ? profileImageUrl : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+    public User findByUserReferenceId(String userReferenceId) {
+        return userRepository.findByUserReferenceId(userReferenceId)
+                .orElse(null);
+    }
+
+    public void updateUserProfileImage(User user) {
+        userRepository.save(user);
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/util/JwtUtil.java
+++ b/auth-service/src/main/java/club/gach_dong/util/JwtUtil.java
@@ -33,7 +33,7 @@ public class JwtUtil {
     public String generateUserToken(User user) {
         return Jwts.builder()
                 .setSubject(user.getEmail())
-                .claim("user_reference_id", user.getUser_reference_id().toString())
+                .claim("user_reference_id", user.getUserReferenceId())
                 .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 1일 후 만료
                 .signWith(userJwtKey, SignatureAlgorithm.HS512)
                 .compact();
@@ -42,7 +42,7 @@ public class JwtUtil {
     public String generateAdminToken(Admin admin) {
         return Jwts.builder()
                 .setSubject(admin.getEmail())
-                .claim("user_reference_id", admin.getUser_reference_id().toString())
+                .claim("user_reference_id", admin.getUserReferenceId())
                 .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 1일 후 만료
                 .signWith(adminJwtKey, SignatureAlgorithm.HS512)
                 .compact();
@@ -60,6 +60,18 @@ public class JwtUtil {
         }
     }
 
+    public String getUserReferenceIdFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .setSigningKey(userJwtKey)
+                    .parseClaimsJws(token.replace("Bearer ", ""))
+                    .getBody();
+            return claims.get("user_reference_id", String.class);
+        } catch (Exception e) {
+            throw new RuntimeException("유효하지 않은 사용자 토큰입니다.");
+        }
+    }
+
     public String getAdminEmailFromToken(String token) {
         try {
             return Jwts.parser()
@@ -67,6 +79,18 @@ public class JwtUtil {
                     .parseClaimsJws(token.replace("Bearer ", ""))
                     .getBody()
                     .getSubject();
+        } catch (Exception e) {
+            throw new RuntimeException("유효하지 않은 관리자 토큰입니다.");
+        }
+    }
+
+    public String getAdminReferenceIdFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .setSigningKey(adminJwtKey)
+                    .parseClaimsJws(token.replace("Bearer ", ""))
+                    .getBody();
+            return claims.get("user_reference_id", String.class);
         } catch (Exception e) {
             throw new RuntimeException("유효하지 않은 관리자 토큰입니다.");
         }

--- a/auth-service/src/main/resources/application.yaml
+++ b/auth-service/src/main/resources/application.yaml
@@ -40,3 +40,7 @@ jwt:
 logging:
   level:
     org.hibernate.SQL: debug
+
+user:
+  service:
+    url: ${USER_SERVICE_URL}


### PR DESCRIPTION
## 1. 관련 이슈

#100 

## 2. 구현한 내용 또는 수정한 내용

- RestTemplate을 사용하여 user-service와의 통신을 통하여 auth-service의 프로필 조회 api에 profileImageUrl을 추가합니다.
- auth-service의 필드를 user_Reference_Id -> userReferenceId로 수정합니다.
- userReferenceId의 타입을 UUID -> String으로 변경합니다.

## 3. TODO

## 4. 배포 전 Checklist
auth-service에 다음과 같은 환경변수가 추가되었습니다. 
 user-service의 프로필 이미지 조회 api의 실제 게이트웨이 엔드포인트 주소가 됩니다.
```
user:
  service:
    url: ${USER_SERVICE_URL}
```
