### PR TITLE
[FEAT] 임시 저장 상태인 지원 내역에 대하여 조회하는 API

### DIFF
--- a/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationApiSpecification.java
@@ -59,6 +59,11 @@ public interface ApplicationApiSpecification {
     @DeleteMapping("/apply/{applyId}")
     ResForm<?> deleteApplication(@PathVariable("applyId") Long applyId, @RequestUserReferenceId String userReferenceId);
 
+    @Operation(summary = "사용자 임시저장 여부 및 내용 반환 API", description = "지원 ID를 이용해 해당 사용자가 해당 임시적으로 저장한 지원이 있는지 확인 및 내용을 반환합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @GetMapping("/apply/{applyId}")
+    ResForm<?> getTempApplication(@PathVariable("applyId") Long recruitmentId,
+                                  @RequestUserReferenceId String userReferenceId);
+
 //    @Operation(summary = "지원 상세 조회 API", description = "지원 ID를 이용해 지원 내역을 조회합니다.")
 //    @DeleteMapping("/admin/{applicationId}")
 //    ResForm<?> getApplication(@PathVariable("applicationId") Long applicationId, HttpServletRequest httpServletRequest);

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationController.java
@@ -66,6 +66,14 @@ public class ApplicationController implements ApplicationApiSpecification {
         return ResForm.onSuccess(InSuccess.APPLICATION_DELETED, null);
     }
 
+    @Override
+    public ResForm<ApplicationResponseDTO.ToGetApplicationTempDTO> getTempApplication(Long recruitmentId,
+                                                                                      String userReferenceId) {
+        ApplicationResponseDTO.ToGetApplicationTempDTO applicationTempDTO = applicationService.getApplicationTemp(
+                recruitmentId, userReferenceId);
+        return ResForm.onSuccess(InSuccess.APPLICATION_TEMP_STATUS_GET_SUCCESS, applicationTempDTO);
+    }
+
 //    @Override
 //    public ResForm<?> getApplication(Long applicationId, HttpServletRequest httpServletRequest) {
 //        return null;

--- a/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
@@ -106,4 +106,15 @@ public class ApplicationResponseDTO {
         @Schema(description = "답변 내용", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
         private Map<String, Object> applicationBody;
     }
+
+    @Getter
+    @Builder
+    @Schema(description = "사용자용 특정 지원에 대한 임시저장 여부 반환 DTO")
+    public static class ToGetApplicationTempDTO {
+        @Schema(description = "임시 저장된 지원 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private Long applicationId;
+
+        @Schema(description = "임시 저장된 답변 내용", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private Map<String, Object> applicationBody;
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
@@ -61,6 +61,9 @@ public class ApplicationResponseDTO {
 
         @Schema(description = "지원한 날짜", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
         private LocalDateTime submitDate;
+
+//        @Schema(description = "지원 응답 내용(Json)", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+//        private Map<String, Object> applicationBody;
     }
 
     @Getter

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -21,4 +21,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     void updateApplicationStatus(@Param("status") String status, @Param("application") Application application);
 
     List<Application> findAllByApplyIdAndApplicationStatus(Long applyId, String status);
+
+    Optional<Application> findByApplyIdAndApplicationStatusAndUserId(Long applyId, String status, String userId);
 }

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -21,9 +21,7 @@ public enum InSuccess {
     APPLICATION_CHANGED(HttpStatus.OK, "APPLICATION203", "신청 수정에 성공했습니다."),
     APPLICATION_HISTORY_GET_SUCCESS(HttpStatus.OK, "APPLICATION204", "지원 내역 조회에 성공했습니다."),
     APPLICATION_STATUS_CHANGED(HttpStatus.OK, "APPLICATION205", "지원 상태 수정에 성공했습니다."),
-
-
-    ;
+    APPLICATION_TEMP_STATUS_GET_SUCCESS(HttpStatus.OK, "APPLICATION206", "해당 지원의 임시저장 정보 확인에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -239,6 +239,7 @@ public class ApplicationService {
                         .clubName(application.getClubName())
                         .status(application.getApplicationStatus())
                         .submitDate(application.getSubmitDate())
+//                        .applicationBody(application.getApplicationBody())
                         .build())
                 .collect(Collectors.toList());
 

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -288,4 +288,20 @@ public class ApplicationService {
                 .toGetApplicationDTO(toGetApplicationDTOs)
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public ApplicationResponseDTO.ToGetApplicationTempDTO getApplicationTemp(Long recruitmentId, String userId) {
+
+        Application application = applicationRepository.findByApplyIdAndApplicationStatusAndUserId(recruitmentId,
+                "TEMPORARY_SAVED", userId).orElse(null);
+
+        if (application == null) {
+            return null;
+        }
+
+        return ApplicationResponseDTO.ToGetApplicationTempDTO.builder()
+                .applicationId(application.getId())
+                .applicationBody(application.getApplicationBody())
+                .build();
+    }
 }


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/97

## 2. 구현한 내용 또는 수정한 내용

임시 저장 상태인 지원에 대하여 조회하는 API를 추가했습니다.
만약 해당 지원에 대하여 임시 저장된 지원이 없다면 아무것도 반환하지 않습니다.

## 3. TODO
추후 코드 전반에 존재하는 applyId인 속성 명을 recruitmentId로 수정할 예정입니다.

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->