### PR TITLE
[FIX] 관리자가 특정 recruitment의 지원 내역 조회 시 사용자 정보 가져오는 Logic 추가

### DIFF
--- a/application-service/src/main/java/club/gach_dong/controller/MockUpController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/MockUpController.java
@@ -1,10 +1,19 @@
 package club.gach_dong.controller;
 
 
+import club.gach_dong.dto.response.AuthResponseDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,6 +38,43 @@ public class MockUpController {
         System.out.println("reqq-id: " + headerValue);
         System.out.println("applyId: " + applyId);
         return true;
+    }
+
+    @PostMapping("/profile")
+    public List<AuthResponseDTO.getUserProfile> getUserProfiles(@RequestBody Map<String, List<String>> request) {
+        System.out.println("통신 체결 apply is valid");
+
+        List<String> userReferenceIds = request.get("userReferenceId");
+        if (userReferenceIds == null || userReferenceIds.isEmpty()) {
+            throw new IllegalArgumentException("userReferenceId list is required");
+        }
+        
+        return userReferenceIds.stream()
+                .map(id -> AuthResponseDTO.getUserProfile.builder()
+                        .userReferenceId(id)
+                        .profileImageUrl("http://testtesttest")
+                        .email("test@gachon.ac.kr")
+                        .name("tester")
+                        .role("USER")
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Getter
+    @Builder
+    public static class testUserDetailDTO {
+        @Schema(description = "사용자 이메일", example = "user@gachon.ac.kr")
+        String email;
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name;
+
+        @Schema(description = "사용자 권한", example = "USER, ADMIN")
+        String role;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
+        String profileImageUrl;
+
     }
 
 //    @DeleteMapping("/test")

--- a/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
@@ -94,6 +94,18 @@ public class ApplicationResponseDTO {
         @Schema(description = "지원 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
         private Long applicationId;
 
+        @Schema(description = "지원자 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private String userReferenceId;
+
+        @Schema(description = "지원자 email", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private String userEmail;
+
+        @Schema(description = "지원자 이름", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private String userName;
+
+        @Schema(description = "지원자 프로필 이미지", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private String userProfileUrl;
+
         @Schema(description = "지원 상태(합격, 불합격, 서류 합격 등)", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
         private String status;
 

--- a/application-service/src/main/java/club/gach_dong/dto/response/AuthResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/AuthResponseDTO.java
@@ -1,0 +1,29 @@
+package club.gach_dong.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthResponseDTO {
+
+    @Getter
+    @Builder
+    @Schema(description = "내부 Service Mesh용 DTO (FrontEnd와는 관계가 없습니다.)")
+    public static class getUserProfile {
+        @Schema(description = "사용자 ID", example = "654fdh46-658fdg")
+        String userReferenceId;
+
+        @Schema(description = "사용자 이메일", example = "user@gachon.ac.kr")
+        String email;
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name;
+
+        @Schema(description = "사용자 권한", example = "USER, ADMIN")
+        String role;
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.png")
+        String profileImageUrl;
+    }
+
+}

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -101,6 +102,15 @@ public class AuthorizationService {
             throw new ClubException.ClubAdminCommunicateFailedException();
 //            return false;
         }
+    }
+
+    @Deprecated
+    public String getToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        throw new UserException.UserNotFound();
     }
 
 

--- a/application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java
@@ -1,0 +1,51 @@
+package club.gach_dong.service;
+
+import club.gach_dong.dto.response.AuthResponseDTO;
+import club.gach_dong.exception.UserException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class ServiceMeshService {
+    @Value("${msa.url.userDetail}")
+    private String userDetailUrl;
+
+    public final RestClient restClient;
+
+    public List<AuthResponseDTO.getUserProfile> getUserProfiles(List<String> userIds) {
+        String uri = UriComponentsBuilder.fromHttpUrl(userDetailUrl)
+                .path("/profile")
+                .toUriString();
+
+        Map<String, List<String>> requestBody = new HashMap<>();
+        requestBody.put("userReferenceId", userIds);
+
+        try {
+            return restClient.post()
+                    .uri(uri)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer ")
+                    .body(requestBody)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<List<AuthResponseDTO.getUserProfile>>() {
+                    });
+
+        } catch (RestClientException e) {
+            System.err.println("REST 클라이언트 오류 발생: " + e.getMessage());
+            throw new UserException.UserNotFound();
+        } catch (Exception e) {
+            System.err.println("예상치 못한 오류 발생: " + e.getMessage());
+            throw new UserException.UserNotFound();
+        }
+    }
+}

--- a/application-service/src/main/resources/application.yaml
+++ b/application-service/src/main/resources/application.yaml
@@ -46,4 +46,5 @@ msa:
     club: ${CLUB_URL}
     auth: ${CLUB_AUTH}
     apply: ${CLUB_APPLY}
+    userDetail: ${USER_DETAIL_URL}
 


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/103

## 2. 구현한 내용 또는 수정한 내용

관리자가 특정 recruitment의 지원 내역 조회 시 사용자 정보를 Auth Domain으로의 통신으로 가져옵니다.
- REST Cleint의 Post를 사용하여 정보를 가져옵니다.
- USER_DETAIL_URL을 Secret에 추가할 필요가 있습니다. (현재 Auth Domain의 API가 배포가 안된 관계로 Application Domain의 root 경로로 연결하면 됩니다.)

## 3. TODO
URL 경로 수정이 필요합니다. (해당 API가 배포된 후 수정 예정)
- application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java의 27번째 줄

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->