### PR TITLE
[FEAT] auth-service의 refresh token 추가 및 다수의 사용자 프로필 조회 api 추가

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/api/AdminAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AdminAuthApiSpecification.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import club.gach_dong.dto.request.ChangePasswordRequest;
+import club.gach_dong.dto.response.TokenResponse;
 import club.gach_dong.dto.response.UserProfileResponse;
 
 @Tag(name = "관리자 인증/인가 API", description = "관리자 인증 및 인가 관련 API")
@@ -23,7 +24,8 @@ public interface AdminAuthApiSpecification {
     @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.")
     @PostMapping("/logout")
     ResponseEntity<String> logout(
-            @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
+            @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
+            @Parameter(description = "Refresh Token") @RequestHeader("Refresh-Token") String refreshToken);
 
     @Operation(summary = "회원탈퇴", description = "사용자의 계정을 삭제합니다.")
     @PostMapping("/unregister")
@@ -34,4 +36,9 @@ public interface AdminAuthApiSpecification {
     @GetMapping("/profile")
     ResponseEntity<UserProfileResponse> getProfile(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
+
+    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @PostMapping("/refresh-token")
+    ResponseEntity<TokenResponse> refreshToken(
+            @Parameter(description = "Refresh Token") @RequestHeader("Authorization") String refreshToken);
 }

--- a/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import club.gach_dong.dto.request.ChangePasswordRequest;
+import club.gach_dong.dto.response.TokenResponse;
 import club.gach_dong.dto.response.UserProfileResponse;
 
 @Tag(name = "사용자 인증/인가 API", description = "사용자 인증 및 인가 관련 API")
@@ -23,7 +24,8 @@ public interface AuthApiSpecification {
     @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.")
     @PostMapping("/logout")
     ResponseEntity<String> logout(
-            @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
+            @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
+            @Parameter(description = "Refresh Token") @RequestHeader("Refresh-Token") String refreshToken);
 
     @Operation(summary = "회원탈퇴", description = "사용자의 계정을 삭제합니다.")
     @PostMapping("/unregister")
@@ -34,4 +36,9 @@ public interface AuthApiSpecification {
     @GetMapping("/profile")
     ResponseEntity<UserProfileResponse> getProfile(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
+
+    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @PostMapping("/refresh-token")
+    ResponseEntity<TokenResponse> refreshToken(
+            @Parameter(description = "Refresh Token") @RequestHeader("Authorization") String refreshToken);
 }

--- a/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/PublicAuthApiSpecification.java
@@ -8,7 +8,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import club.gach_dong.dto.request.LoginRequest;
 import club.gach_dong.dto.request.RegistrationRequest;
+import club.gach_dong.dto.request.ProfilesRequest;
 import club.gach_dong.dto.response.AuthResponse;
+import club.gach_dong.dto.response.UserProfileResponse;
+
+import java.util.List;
 
 @Tag(name = "Public 사용자 인증/인가 API", description = "Public한 사용자 인증 및 인가 관련 API")
 @RestController
@@ -50,4 +54,9 @@ public interface PublicAuthApiSpecification {
     ResponseEntity<String> verifyCode(
             @Parameter(description = "사용자의 이메일 주소") @RequestParam String email,
             @Parameter(description = "인증 코드") @RequestParam String code);
+
+    @Operation(summary = "사용자 및 관리자 프로필 조회", description = "주어진 userReferenceId 목록에 대한 사용자 및 관리자 프로필을 조회합니다.")
+    @PostMapping("/profiles")
+    ResponseEntity<List<UserProfileResponse>> getProfiles(
+            @Parameter(description = "사용자 및 관리자의 userReferenceId 목록") @Valid @RequestBody ProfilesRequest profilesRequest);
 }

--- a/auth-service/src/main/java/club/gach_dong/controller/PublicAdminAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/PublicAdminAuthController.java
@@ -54,8 +54,10 @@ public class PublicAdminAuthController implements PublicAdminAuthApiSpecificatio
                     .body(AuthResponse.withMessage("계정이 활성화되지 않았습니다."));
         }
 
-        String token = jwtUtil.generateAdminToken(admin);
-        return ResponseEntity.ok(AuthResponse.of(token));
+        String accessToken = jwtUtil.generateAdminToken(admin);
+        String refreshToken = jwtUtil.generateAdminRefreshToken(admin);
+
+        return ResponseEntity.ok(AuthResponse.of(accessToken, refreshToken));
     }
 
 

--- a/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
@@ -73,9 +73,12 @@ public class PublicAuthController implements PublicAuthApiSpecification {
                     .body(AuthResponse.withMessage("계정이 활성화되지 않았습니다."));
         }
 
-        String token = jwtUtil.generateUserToken(user);
-        return ResponseEntity.ok(AuthResponse.of(token));
+        String accessToken = jwtUtil.generateUserToken(user);
+        String refreshToken = jwtUtil.generateUserRefreshToken(user);
+
+        return ResponseEntity.ok(AuthResponse.of(accessToken, refreshToken));
     }
+
 
     @Override
     public ResponseEntity<String> resetPassword(@RequestParam String email, @RequestParam String code) {

--- a/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/PublicAuthController.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class PublicAuthController implements PublicAuthApiSpecification {
 
@@ -31,7 +30,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     private final AdminService adminService;
 
     @Override
-    @PostMapping("/send_verification_code")
     public ResponseEntity<String> sendVerificationCode(@RequestParam String email) {
         try {
             userService.sendVerificationCode(email);
@@ -42,7 +40,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
-    @PostMapping("/send_registration_verification_code")
     public ResponseEntity<String> sendRegistrationVerificationCode(@RequestParam String email) {
         try {
             userService.sendRegistrationVerificationCode(email);
@@ -53,7 +50,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
-    @PostMapping("/register")
     public ResponseEntity<String> completeRegistration(@Valid @RequestBody RegistrationRequest registrationRequest) {
         try {
             userService.completeRegistration(registrationRequest);
@@ -64,7 +60,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
-    @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
         User user = userService.findByEmail(loginRequest.email());
 
@@ -83,7 +78,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
-    @PostMapping("/reset-password")
     public ResponseEntity<String> resetPassword(@RequestParam String email, @RequestParam String code) {
         try {
             userService.verifyCode(email, code);
@@ -97,7 +91,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
-    @PostMapping("/verify-code")
     public ResponseEntity<String> verifyCode(@RequestParam String email, @RequestParam String code) {
         try {
             userService.verifyCode(email, code);
@@ -108,7 +101,6 @@ public class PublicAuthController implements PublicAuthApiSpecification {
     }
 
     @Override
-    @PostMapping("/profiles")
     public ResponseEntity<List<UserProfileResponse>> getProfiles(
             @Valid @RequestBody ProfilesRequest profilesRequest) {
 

--- a/auth-service/src/main/java/club/gach_dong/dto/request/ProfilesRequest.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/request/ProfilesRequest.java
@@ -1,0 +1,12 @@
+package club.gach_dong.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ProfilesRequest(
+        @NotNull
+        @Schema(description = "UUID 목록", example = "[\"uuid1\", \"uuid2\", \"uuid3\"]")
+        List<String> userReferenceId
+) {}

--- a/auth-service/src/main/java/club/gach_dong/dto/response/AuthResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/AuthResponse.java
@@ -4,16 +4,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record AuthResponse(
         @Schema(description = "JWT 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-        String token,
+        String accessToken,
+
+        @Schema(description = "Refresh 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String refreshToken,
 
         @Schema(description = "응답 메시지", example = "로그인 성공")
         String message
 ) {
-    public static AuthResponse of(String token) {
-        return new AuthResponse(token, "로그인 성공");
+    public static AuthResponse of(String accessToken, String refreshToken) {
+        return new AuthResponse(accessToken, refreshToken, "로그인 성공");
     }
 
     public static AuthResponse withMessage(String message) {
-        return new AuthResponse(null, message);
+        return new AuthResponse(null, null, message);
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/dto/response/TokenResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/TokenResponse.java
@@ -1,4 +1,4 @@
-package test.login.dto.response;
+package club.gach_dong.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/auth-service/src/main/java/club/gach_dong/dto/response/TokenResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/TokenResponse.java
@@ -1,0 +1,19 @@
+package test.login.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenResponse(
+        @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String accessToken,
+
+        @Schema(description = "응답 메시지", example = "Access Token 재발급 성공")
+        String message
+) {
+    public static TokenResponse of(String accessToken) {
+        return new TokenResponse(accessToken, "Access Token 재발급 성공");
+    }
+
+    public static TokenResponse withMessage(String message) {
+        return new TokenResponse(null, message);
+    }
+}

--- a/auth-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
@@ -1,10 +1,13 @@
 package club.gach_dong.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import club.gach_dong.entity.Admin;
-import club.gach_dong.entity.User;
+import test.login.entity.Admin;
+import test.login.entity.User;
 
 public record UserProfileResponse(
+        @Schema(description = "사용자 고유 식별자", example = "uuid-1234-5678")
+        String userReferenceId,
+
         @Schema(description = "사용자 이메일", example = "user@gachon.ac.kr")
         String email,
 
@@ -19,6 +22,7 @@ public record UserProfileResponse(
 ) {
     public static UserProfileResponse from(User user) {
         return new UserProfileResponse(
+                user.getUserReferenceId(),
                 user.getEmail(),
                 user.getName(),
                 user.getRole().name(),
@@ -28,6 +32,7 @@ public record UserProfileResponse(
 
     public static UserProfileResponse from(Admin admin) {
         return new UserProfileResponse(
+                admin.getUserReferenceId(),
                 admin.getEmail(),
                 admin.getName(),
                 admin.getRole().name(),

--- a/auth-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/UserProfileResponse.java
@@ -1,8 +1,8 @@
 package club.gach_dong.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import test.login.entity.Admin;
-import test.login.entity.User;
+import club.gach_dong.entity.Admin;
+import club.gach_dong.entity.User;
 
 public record UserProfileResponse(
         @Schema(description = "사용자 고유 식별자", example = "uuid-1234-5678")

--- a/auth-service/src/main/java/club/gach_dong/entity/Admin.java
+++ b/auth-service/src/main/java/club/gach_dong/entity/Admin.java
@@ -15,7 +15,7 @@ public class Admin {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(length = 255, nullable = false, unique = true)
     private String userReferenceId;
 
     @Column(length = 255, nullable = false, unique = true)

--- a/auth-service/src/main/java/club/gach_dong/entity/User.java
+++ b/auth-service/src/main/java/club/gach_dong/entity/User.java
@@ -15,7 +15,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(length = 255, nullable = false, unique = true)
     private String userReferenceId;
 
     @Column(length = 255, nullable = false, unique = true)

--- a/auth-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -155,9 +155,12 @@ public class AdminService {
         jwtUtil.blacklistAdminToken(token);
     }
 
+    public void blacklistAdminRefreshToken(String refreshToken) {
+        jwtUtil.blacklistAdminRefreshToken(refreshToken);
+    }
+
     public String getProfileImageUrl(String userReferenceId) {
         String url = userServiceUrl + userReferenceId;
-
 
         try {
             String profileImageUrl = restTemplate.getForObject(url, String.class);

--- a/auth-service/src/main/java/club/gach_dong/service/UserService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/UserService.java
@@ -174,6 +174,10 @@ public class UserService {
         jwtUtil.blacklistUserToken(token);
     }
 
+    public void blacklistUserRefreshToken(String refreshToken) {
+        jwtUtil.blacklistUserRefreshToken(refreshToken);
+    }
+
     public String getProfileImageUrl(String userReferenceId) {
         String url = userServiceUrl + userReferenceId;
 

--- a/auth-service/src/main/java/club/gach_dong/util/JwtUtil.java
+++ b/auth-service/src/main/java/club/gach_dong/util/JwtUtil.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -31,37 +33,41 @@ public class JwtUtil {
     }
 
     public String generateUserToken(User user) {
+        Date expirationDate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
         return Jwts.builder()
                 .setSubject(user.getEmail())
                 .claim("user_reference_id", user.getUserReferenceId())
-                .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 1일 후 만료
+                .setExpiration(expirationDate)
                 .signWith(userJwtKey, SignatureAlgorithm.HS512)
                 .compact();
     }
 
     public String generateAdminToken(Admin admin) {
+        Date expirationDate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
         return Jwts.builder()
                 .setSubject(admin.getEmail())
                 .claim("user_reference_id", admin.getUserReferenceId())
-                .setExpiration(new Date(System.currentTimeMillis() + 86400000)) // 1일 후 만료
+                .setExpiration(expirationDate)
                 .signWith(adminJwtKey, SignatureAlgorithm.HS512)
                 .compact();
     }
 
     public String generateUserRefreshToken(User user) {
+        Date expirationDate = Date.from(Instant.now().plus(7, ChronoUnit.DAYS));
         return Jwts.builder()
                 .setSubject(user.getEmail())
                 .claim("user_reference_id", user.getUserReferenceId())
-                .setExpiration(new Date(System.currentTimeMillis() + 604800000)) // 7일 후 만료
+                .setExpiration(expirationDate)
                 .signWith(userJwtKey, SignatureAlgorithm.HS512)
                 .compact();
     }
 
     public String generateAdminRefreshToken(Admin admin) {
+        Date expirationDate = Date.from(Instant.now().plus(7, ChronoUnit.DAYS));
         return Jwts.builder()
                 .setSubject(admin.getEmail())
                 .claim("user_reference_id", admin.getUserReferenceId())
-                .setExpiration(new Date(System.currentTimeMillis() + 604800000)) // 7일 후 만료
+                .setExpiration(expirationDate)
                 .signWith(adminJwtKey, SignatureAlgorithm.HS512)
                 .compact();
     }


### PR DESCRIPTION
## 1. 관련 이슈

#108 

## 2. 구현한 내용 또는 수정한 내용

- [x] 로그인 시, refresh token 발급 추가
- [x] refresh token을 사용하여 access token을 발급받는 api 추가 
- [x] 다수의 사용자 프로필 조회 api 추가
- [x] userReferenceId 필드에 column 값 추가
- [x] 기존 사용자 프로필 조회 api에 userReferenceId를 추가로 반환하도록 수정

## 3. TODO

## 4. 배포 전 Checklist
@EeeasyCode 
이제 사용자는 로그인할 때 access token과 refresh token을 같이 발급받습니다. refresh token의 유효기간은 7일입니다.
refresh token은 access token을 재발급받기 위한 api에서 사용됩니다.
사용자의 로그아웃 시, access token과 refresh token을 둘 다 요구하며, 각 토큰은 블랙리스트에 저장됩니다.

@opp-13 
주어진 userReferenceId 목록에 대한 다수의 사용자 및 관리자 프로필을 조회하는 api를 추가하였습니다. 
사용자/관리자 모든 테이블에서 조회합니다.
또한, 기존 사용자 프로필 조회 api에 userReferenceId를 추가로 반환하도록 수정하였습니다.