### PR TITLE
[FIX] 만약 관리자가 지원 내역 조회 시 아무것도 조회 되지 않을 시 예외 처리 추가

### DIFF
--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -271,6 +271,12 @@ public class ApplicationService {
         List<Application> applicationList = applicationRepository.findAllByApplyIdAndApplicationStatus(applyId,
                 "SAVED");
 
+        if (applicationList.isEmpty()) {
+            return ApplicationResponseDTO.ToGetApplicationListAdminDTO.builder()
+                    .toGetApplicationDTO(null)
+                    .build();
+        }
+
 //        if (applicationList.isEmpty()) {
 //            throw new CustomException(ErrorCode.APPLICATION_NOT_PRESENT);
 //        }


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/110

## 2. 구현한 내용 또는 수정한 내용

관리자가 지원 내역 조회 시 아무것도 조회 되지 않을 시 null을 반환하도록 했습니다.
기존의 코드가 500 Error를 내지 않도록 null일 시 바로 null을 반환합니다.

## 3. TODO

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->