### PR TITLE
[FEAT] 요구사항을 위한 동아리 서비스 API 구현 v3

### DIFF
--- a/club-service/src/main/java/club/gach_dong/api/ClubAdminApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubAdminApiSpecification.java
@@ -111,6 +111,19 @@ public interface ClubAdminApiSpecification {
     );
 
     @Operation(
+            summary = "모집 공고 ID를 가지고 특정 동아리에 대한 권한이 있는지 확인",
+            description = "모집 공고 ID를 통해 특정 동아리에 대한 권한이 있는지 확인합니다.",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @GetMapping("/{recruitmentId}/has-authority")
+    Boolean hasAuthorityByRecruitmentId(
+            @RequestUserReferenceId
+            String userReferenceId,
+            @PathParam("recruitmentId")
+            Long recruitmentId
+    );
+
+    @Operation(
             summary = "유효한 동아리 모집 공고인지 확인",
             description = "유효한 동아리 모집 공고인지 확인합니다.",
             security = @SecurityRequirement(name = "Authorization")

--- a/club-service/src/main/java/club/gach_dong/controller/ClubAdminController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubAdminController.java
@@ -81,6 +81,11 @@ public class ClubAdminController implements ClubAdminApiSpecification {
     }
 
     @Override
+    public Boolean hasAuthorityByRecruitmentId(String userReferenceId, Long recruitmentId) {
+        return clubService.hasAuthorityByRecruitmentId(userReferenceId, recruitmentId);
+    }
+
+    @Override
     public Boolean isValidRecruitment(Long recruitmentId) {
         LocalDateTime currentDateTime = LocalDateTime.now();
         return clubService.isValidRecruitment(recruitmentId, currentDateTime);

--- a/club-service/src/main/java/club/gach_dong/dto/response/CreateClubContactInfoResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/CreateClubContactInfoResponse.java
@@ -12,7 +12,7 @@ public record CreateClubContactInfoResponse(
         @NotNull
         Long ContactId
 ) {
-    public static CreateClubContactInfoResponse of(Long clubId, Long contactId) {
+    public static CreateClubContactInfoResponse from(Long clubId, Long contactId) {
         return new CreateClubContactInfoResponse(clubId, contactId);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/dto/response/CreateClubRecruitmentResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/CreateClubRecruitmentResponse.java
@@ -1,4 +1,19 @@
 package club.gach_dong.dto.response;
 
-public record CreateClubRecruitmentResponse() {
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateClubRecruitmentResponse(
+
+        @Schema(description = "동아리 ID", example = "1")
+        @NotNull
+        Long clubId,
+
+        @Schema(description = "동아리 모집 ID", example = "1", nullable = false)
+        @NotNull
+        Long clubRecruitmentId
+) {
+    public static CreateClubRecruitmentResponse from(Long clubId, Long clubRecruitmentId) {
+        return new CreateClubRecruitmentResponse(clubId, clubRecruitmentId);
+    }
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubService.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubService.java
@@ -35,4 +35,5 @@ public interface ClubService {
     List<AdminAuthorizedClubResponse> getAuthorizedClubs(String userReferenceId);
     Boolean hasAuthority(String userReferenceId, Long clubId);
     Boolean isValidRecruitment(Long recruitmentId, LocalDateTime currentDateTime);
+    Boolean hasAuthorityByRecruitmentId(String userReferenceId, Long recruitmentId);
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -255,4 +255,13 @@ public class ClubServiceImpl implements ClubService {
                 .map(recruitment -> recruitment.isRecruiting(currentDateTime))
                 .orElse(false); // 모집 정보가 없으면 false 반환
     }
+
+    @Override
+    public Boolean hasAuthorityByRecruitmentId(String userReferenceId, Long recruitmentId) {
+        return recruitmentRepository.findById(recruitmentId)
+                .map(Recruitment::getClub)
+                .map(club -> club.getAdmins().stream()
+                        .anyMatch(admin -> admin.getUserReferenceId().equals(userReferenceId)))
+                .orElse(false);
+    }
 }

--- a/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubServiceImpl.java
@@ -2,7 +2,6 @@ package club.gach_dong.service;
 
 import club.gach_dong.domain.Activity;
 import club.gach_dong.domain.Club;
-import club.gach_dong.domain.ClubAdmin;
 import club.gach_dong.domain.ContactInfo;
 import club.gach_dong.domain.Recruitment;
 import club.gach_dong.dto.request.CreateClubActivityRequest;
@@ -25,7 +24,6 @@ import club.gach_dong.repository.ClubRepository;
 import club.gach_dong.repository.RecruitmentRepository;
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -184,7 +182,7 @@ public class ClubServiceImpl implements ClubService {
 
         clubRepository.save(club);
 
-        return CreateClubContactInfoResponse.of(
+        return CreateClubContactInfoResponse.from(
                 club.getId(),
                 contactInfo.getId()
         );
@@ -213,7 +211,10 @@ public class ClubServiceImpl implements ClubService {
 
         clubRepository.save(club);
 
-        return new CreateClubRecruitmentResponse();
+        return CreateClubRecruitmentResponse.from(
+                club.getId(),
+                recruitment.getId()
+        );
     }
 
     @Override


### PR DESCRIPTION
## 1. 관련 이슈
@kangju2000 @opp-13 
요청하신 내용에 대한 기능 수정 및 구현 완료되었습니다!
<!-- 연관된 이슈를 링크해주세요. -->

## 2. 구현한 내용 또는 수정한 내용

<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 혹은 gif 등을 활용해 자유롭게 보여주세요. -->

## 3. TODO
- [ ] create [recruitment response 값 추가](https://github.com/TEAM-YOAJUNG/backend-server/tree/a365469bda386c35b8d10ff6039f335ffd70df7b) @kangju2000 
- [ ] 백엔드를 위한 [동아리 권한 조회 API](https://github.com/TEAM-YOAJUNG/backend-server/tree/0b0f3132b3c3ae06ba81ea87ddd47077365ce4d9) @opp-13 
## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->