### PR TITLE
[FIX] APPLICATION Domain, 클럽 관리자 권한 확인 시 기존 userId를 REFERENCE_ID_HEADER_KEY Header에 넣도록 수정

### DIFF
--- a/application-service/src/main/java/club/gach_dong/controller/MockUpController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/MockUpController.java
@@ -1,6 +1,7 @@
 package club.gach_dong.controller;
 
 
+import club.gach_dong.annotation.RequestUserReferenceId;
 import club.gach_dong.dto.response.AuthResponseDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,11 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class MockUpController {
 
     @GetMapping("/authTest")
-    public Boolean testAuth(@RequestParam String userId, int applyId, HttpServletRequest httpServletRequest) {
+    public Boolean testAuth(@RequestParam int applyId, HttpServletRequest httpServletRequest,
+                            @RequestUserReferenceId String userReferenceId) {
         System.out.println("통신 체결");
         String headerValue = httpServletRequest.getHeader("reqq-id");
         System.out.println("reqq-id: " + headerValue);
-        System.out.println("UserID: " + userId);
+        System.out.println("UserID: " + userReferenceId);
         System.out.println("applyId: " + applyId);
         return true;
     }
@@ -48,7 +50,7 @@ public class MockUpController {
         if (userReferenceIds == null || userReferenceIds.isEmpty()) {
             throw new IllegalArgumentException("userReferenceId list is required");
         }
-        
+
         return userReferenceIds.stream()
                 .map(id -> AuthResponseDTO.getUserProfile.builder()
                         .userReferenceId(id)

--- a/application-service/src/main/java/club/gach_dong/controller/MockUpController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/MockUpController.java
@@ -15,34 +15,33 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class MockUpController {
 
-    @GetMapping("/authTest")
-    public Boolean testAuth(@RequestParam int applyId, HttpServletRequest httpServletRequest,
+    @GetMapping("/{recruitmentId}/has-authority")
+    public Boolean testAuth(@PathVariable Long recruitmentId, HttpServletRequest httpServletRequest,
                             @RequestUserReferenceId String userReferenceId) {
         System.out.println("통신 체결");
         String headerValue = httpServletRequest.getHeader("reqq-id");
         System.out.println("reqq-id: " + headerValue);
         System.out.println("UserID: " + userReferenceId);
-        System.out.println("applyId: " + applyId);
+        System.out.println("applyId: " + recruitmentId);
         return true;
     }
 
-    @GetMapping("/validApplyTest/{applyId}")
-    public Boolean testAuth(@PathVariable Long applyId, HttpServletRequest httpServletRequest) {
+    @GetMapping("/recruitment/{recruitmentId}/is-valid")
+    public Boolean testAuth(@PathVariable Long recruitmentId, HttpServletRequest httpServletRequest) {
         System.out.println("통신 체결 apply is valid");
         String headerValue = httpServletRequest.getHeader("reqq-id");
         System.out.println("reqq-id: " + headerValue);
-        System.out.println("applyId: " + applyId);
+        System.out.println("applyId: " + recruitmentId);
         return true;
     }
 
-    @PostMapping("/profile")
+    @PostMapping("/profiles")
     public List<AuthResponseDTO.getUserProfile> getUserProfiles(@RequestBody Map<String, List<String>> request) {
         System.out.println("통신 체결 apply is valid");
 

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -21,12 +21,6 @@ public class AuthorizationService {
     @Value("${msa.url.club}")
     private String clubUrl;
 
-    @Value("${msa.url.auth}")
-    private String authUrl;
-
-    @Value("${msa.url.apply}")
-    private String applyUrl;
-
     private final static String REFERENCE_ID_HEADER_KEY = "X-USER-REFERENCE-ID";
 
     public final RestClient restClient;
@@ -43,11 +37,11 @@ public class AuthorizationService {
 //        return null;
     }
 
-    public void getAuthByUserIdAndApplyId(String userId, Long applyId) {
+    public void getAuthByUserIdAndApplyId(String userId, Long recruitmentId) {
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
-                .path("/" + authUrl)
-                .queryParam("applyId", applyId)
+                .path("/{recruitmentId}/has-authority")
+                .buildAndExpand(recruitmentId)
                 .toUriString();
 
         try {
@@ -74,11 +68,11 @@ public class AuthorizationService {
         }
     }
 
-    public void getApplyIsValid(Long applyId) {
+    public void getApplyIsValid(Long recruitmentId) {
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
-                .path("/" + applyUrl + "/{applyId}")
-                .buildAndExpand(applyId)
+                .path("/recruitment/{recruitmentId}/is-valid")
+                .buildAndExpand(recruitmentId)
                 .toUriString();
 
         try {

--- a/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/AuthorizationService.java
@@ -47,7 +47,6 @@ public class AuthorizationService {
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubUrl)
                 .path("/" + authUrl)
-                .queryParam("userId", userId)
                 .queryParam("applyId", applyId)
                 .toUriString();
 
@@ -55,6 +54,7 @@ public class AuthorizationService {
             Boolean result = restClient.get()
                     .uri(uri)
                     .accept(MediaType.APPLICATION_JSON)
+                    .header(REFERENCE_ID_HEADER_KEY, userId)
                     .retrieve()
                     .body(Boolean.class);
 

--- a/application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java
@@ -24,7 +24,7 @@ public class ServiceMeshService {
 
     public List<AuthResponseDTO.getUserProfile> getUserProfiles(List<String> userIds) {
         String uri = UriComponentsBuilder.fromHttpUrl(userDetailUrl)
-                .path("/profile")
+                .path("/profiles")
                 .toUriString();
 
         Map<String, List<String>> requestBody = new HashMap<>();


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/pull/112

## 2. 구현한 내용 또는 수정한 내용

클럽 관리자 권한 확인 API에서 기존 userId를 REFERENCE_ID_HEADER_KEY Header에 넣도록 수정

## 3. TODO
추후 기존 userId 변수명을 userReferenceId로 변경할 예정입니다.

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->