### PR TITLE
[FEAT] applicationId로 지원 내역 단건 조회하는 API 추가

### DIFF
--- a/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
@@ -58,7 +58,7 @@ public interface ApplicationAdminApiSpecification {
     ResForm<?> getClubApplicationList(@PathVariable("applyId") Long applyId,
                                       @RequestUserReferenceId String userReferenceId);
 
-    @Operation(summary = "지원 내역 단건 조회 API", description = "지원 ID를 이용해 지원 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @Operation(summary = "지원 내역 단건 조회 API", description = "applicationId를 이용해 지원 내역 단건을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("application/{applicationId}")
     ResForm<?> getClubApplication(@PathVariable("applicationId") Long applicationId,
                                   @RequestUserReferenceId String userReferenceId);

--- a/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
@@ -53,8 +53,13 @@ public interface ApplicationAdminApiSpecification {
             @Valid @RequestBody ApplicationRequestDTO.ToChangeApplicationStatus toChangeApplicationStatus,
             @RequestUserReferenceId String userReferenceId);
 
-    @Operation(summary = "지원 목록 조회 API", description = "지원 ID를 이용해 지원 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @Operation(summary = "지원 목록 조회 API", description = "지원 ID를(recruitmentId) 이용해 지원 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("/{applyId}")
     ResForm<?> getClubApplicationList(@PathVariable("applyId") Long applyId,
                                       @RequestUserReferenceId String userReferenceId);
+
+    @Operation(summary = "지원 내역 단건 조회 API", description = "지원 ID를 이용해 지원 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @GetMapping("application/{applicationId}")
+    ResForm<?> getClubApplication(@PathVariable("applicationId") Long applicationId,
+                                  @RequestUserReferenceId String userReferenceId);
 }

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationAdminController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationAdminController.java
@@ -71,4 +71,12 @@ public class ApplicationAdminController implements ApplicationAdminApiSpecificat
 
         return ResForm.onSuccess(InSuccess._OK, toGetApplicationListAdminDTO);
     }
+
+    @Override
+    public ResForm<ApplicationResponseDTO.ToGetApplicationDTO> getClubApplication(Long applicationId,
+                                                                                  String userReferenceId) {
+        ApplicationResponseDTO.ToGetApplicationDTO toGetApplicationDTO = applicationService.getApplicationAdmin(
+                userReferenceId, applicationId);
+        return ResForm.onSuccess(InSuccess.APPLICATION_GET_SUCCESS, toGetApplicationDTO);
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/InSuccess.java
@@ -21,7 +21,8 @@ public enum InSuccess {
     APPLICATION_CHANGED(HttpStatus.OK, "APPLICATION203", "신청 수정에 성공했습니다."),
     APPLICATION_HISTORY_GET_SUCCESS(HttpStatus.OK, "APPLICATION204", "지원 내역 조회에 성공했습니다."),
     APPLICATION_STATUS_CHANGED(HttpStatus.OK, "APPLICATION205", "지원 상태 수정에 성공했습니다."),
-    APPLICATION_TEMP_STATUS_GET_SUCCESS(HttpStatus.OK, "APPLICATION206", "해당 지원의 임시저장 정보 확인에 성공했습니다.");
+    APPLICATION_TEMP_STATUS_GET_SUCCESS(HttpStatus.OK, "APPLICATION206", "해당 지원의 임시저장 정보 확인에 성공했습니다."),
+    APPLICATION_GET_SUCCESS(HttpStatus.OK, "APPLICATION207", "해당 지원자의 지원 내역 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/119

## 2. 구현한 내용 또는 수정한 내용

지원 내역 단건 조회 API를 추가했습니다.
ApplicationId를 이용하여 동아리 관리자가 지원 내용을 조회할 수 있습니다.

## 3. TODO

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->