### PR TITLE
[FEAT] Application Form에 clubId 및 관련 API 추가

### DIFF
--- a/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
+++ b/application-service/src/main/java/club/gach_dong/api/ApplicationAdminApiSpecification.java
@@ -62,4 +62,10 @@ public interface ApplicationAdminApiSpecification {
     @GetMapping("application/{applicationId}")
     ResForm<?> getClubApplication(@PathVariable("applicationId") Long applicationId,
                                   @RequestUserReferenceId String userReferenceId);
+
+    @Operation(summary = "club이 가지고 있는 지원서 양식 목록 조회 API", description = "clubId를 이용해 지원서 목록을 조회합니다.", security = @SecurityRequirement(name = "Authorization"))
+    @GetMapping("form/list/{clubId}")
+    ResForm<?> getClubApplicationFormList(@PathVariable("clubId") Long clubId,
+                                          @RequestUserReferenceId String userReferenceId);
+
 }

--- a/application-service/src/main/java/club/gach_dong/controller/ApplicationAdminController.java
+++ b/application-service/src/main/java/club/gach_dong/controller/ApplicationAdminController.java
@@ -3,10 +3,12 @@ package club.gach_dong.controller;
 import club.gach_dong.api.ApplicationAdminApiSpecification;
 import club.gach_dong.dto.request.ApplicationRequestDTO;
 import club.gach_dong.dto.response.ApplicationResponseDTO;
+import club.gach_dong.dto.response.ApplicationResponseDTO.ToGetFormInfoAdminDTO;
 import club.gach_dong.response.ResForm;
 import club.gach_dong.response.status.InSuccess;
 import club.gach_dong.service.ApplicationService;
 import club.gach_dong.service.AuthorizationService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -78,5 +80,13 @@ public class ApplicationAdminController implements ApplicationAdminApiSpecificat
         ApplicationResponseDTO.ToGetApplicationDTO toGetApplicationDTO = applicationService.getApplicationAdmin(
                 userReferenceId, applicationId);
         return ResForm.onSuccess(InSuccess.APPLICATION_GET_SUCCESS, toGetApplicationDTO);
+    }
+
+    @Override
+    public ResForm<List<ToGetFormInfoAdminDTO>> getClubApplicationFormList(Long clubId, String userReferenceId) {
+        List<ApplicationResponseDTO.ToGetFormInfoAdminDTO> toGetFormInfoAdminDTOList = applicationService.toGetFormInfoListAdmin(
+                userReferenceId, clubId);
+
+        return ResForm.onSuccess(InSuccess._OK, toGetFormInfoAdminDTOList);
     }
 }

--- a/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
+++ b/application-service/src/main/java/club/gach_dong/domain/ApplicationForm.java
@@ -37,6 +37,9 @@ public class ApplicationForm {
     @Column(name = "form_name", nullable = false, length = 50)
     private String formName;
 
+    @Column(name = "club_Id", nullable = false)
+    private Long clubId;
+
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "application_form_body", nullable = false, columnDefinition = "json", length = 2000)
     private Map<String, Object> body;

--- a/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/request/ApplicationRequestDTO.java
@@ -22,10 +22,14 @@ public class ApplicationRequestDTO {
         @Pattern(regexp = "TEMPORARY_SAVED|SAVED", message = "지원 양식 상태는 TEMPORARY_SAVED 또는 SAVED 이어야 합니다.")
         private String status;
 
-        @Schema(description = "지원서 양식 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false, example = "가츠동 지원서 양식")
+        @Schema(description = "지원서 이름", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false, example = "가츠동 지원서 이름")
         @NotNull(message = "지원서 이름이 누락되었습니다.")
         @Size(max = 50, message = "지원서 이름은 50자 이내여야 합니다.")
         private String formName;
+
+        @Schema(description = "동아리 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false, example = "21")
+        @NotNull(message = "동아리 ID가 누락되었습니다.")
+        private Long clubId;
 
         @Schema(
                 description = "지원서 양식 본문, Json 형식으로 넣어주세요.",

--- a/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/ApplicationResponseDTO.java
@@ -23,6 +23,12 @@ public class ApplicationResponseDTO {
 
         @Schema(description = "지원서 양식 상태 (임시 저장인지, 삭제 가능한지 등)", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
         private String formStatus;
+
+        @Schema(description = "동아리 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private Long clubId;
+
+        @Schema(description = "지원 ID", requiredMode = Schema.RequiredMode.REQUIRED, nullable = false)
+        private Long applyId;
     }
 
     @Getter

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationFormRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationFormRepository.java
@@ -1,11 +1,12 @@
 package club.gach_dong.repository;
 
 import club.gach_dong.domain.ApplicationForm;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ApplicationFormRepository extends JpaRepository<ApplicationForm, Long> {
-
+    List<ApplicationForm> findAllByClubId(Long clubId);
 
 }

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -57,6 +57,7 @@ public class ApplicationService {
                 .applicationFormStatus(ApplicationFormStatus.valueOf(toCreateApplicationFormDTO.getStatus()))
                 .formName(toCreateApplicationFormDTO.getFormName())
                 .applyId(toCreateApplicationFormDTO.getApplyId())
+                .clubId(toCreateApplicationFormDTO.getClubId())
                 .body(toCreateApplicationFormDTO.getFormBody())
                 .build();
 
@@ -81,6 +82,8 @@ public class ApplicationService {
                 .formName(applicationForm.getFormName())
                 .formBody(applicationForm.getBody())
                 .formStatus(String.valueOf(applicationForm.getApplicationFormStatus()))
+                .clubId(applicationForm.getClubId())
+                .applyId(applicationForm.getApplyId())
                 .build();
     }
 
@@ -360,4 +363,28 @@ public class ApplicationService {
                 .submitDate(application.getSubmitDate())
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public List<ApplicationResponseDTO.ToGetFormInfoAdminDTO> toGetFormInfoListAdmin(String userId, Long clubId) {
+        List<ApplicationForm> applicationFormList = applicationFormRepository.findAllByClubId(clubId);
+
+        if (applicationFormList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        ApplicationForm firstForm = applicationFormList.get(0);
+        authorizationService.getAuthByUserIdAndApplyId(userId, firstForm.getApplyId());
+
+        return applicationFormList.stream()
+                .map(applicationForm -> ApplicationResponseDTO.ToGetFormInfoAdminDTO.builder()
+                        .formId(applicationForm.getId())
+                        .formName(applicationForm.getFormName())
+                        .formBody(applicationForm.getBody())
+                        .formStatus(String.valueOf(applicationForm.getApplicationFormStatus()))
+                        .clubId(applicationForm.getClubId())
+                        .applyId(applicationForm.getApplyId())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/application-service/src/main/resources/application.yaml
+++ b/application-service/src/main/resources/application.yaml
@@ -44,7 +44,5 @@ spring:
 msa:
   url:
     club: ${CLUB_URL}
-    auth: ${CLUB_AUTH}
-    apply: ${CLUB_APPLY}
     userDetail: ${USER_DETAIL_URL}
 


### PR DESCRIPTION

## 1. 관련 이슈

https://github.com/TEAM-YOAJUNG/backend-server/issues/122

## 2. 구현한 내용 또는 수정한 내용

admin/api/v1/form/list/{clubId}로 요청 시 clubId에 존재하는 지원서 양식 전체가 조회됩니다.

지원서 양식 생성 시 clubId가 삽입되어야 합니다.

## 3. TODO

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->