### PR TITLE
[FEAT] auth-service 사용자 이름 변경 api 추가

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/api/AdminAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AdminAuthApiSpecification.java
@@ -2,11 +2,13 @@ package club.gach_dong.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import club.gach_dong.dto.request.ChangePasswordRequest;
+import club.gach_dong.dto.response.ChangeNameResponse;
 import club.gach_dong.dto.response.TokenResponse;
 import club.gach_dong.dto.response.UserProfileResponse;
 
@@ -15,30 +17,42 @@ import club.gach_dong.dto.response.UserProfileResponse;
 @RequestMapping("admin/api/v1")
 public interface AdminAuthApiSpecification {
 
-    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 변경합니다.")
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 변경합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/change-password")
     ResponseEntity<String> changePassword(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
             @Parameter(description = "비밀번호 변경 정보") @Valid @RequestBody ChangePasswordRequest changePasswordRequest);
 
-    @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.")
+    @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/logout")
     ResponseEntity<String> logout(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
             @Parameter(description = "Refresh Token") @RequestHeader("Refresh-Token") String refreshToken);
 
-    @Operation(summary = "회원탈퇴", description = "사용자의 계정을 삭제합니다.")
+    @Operation(summary = "회원탈퇴", description = "사용자의 계정을 삭제합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/unregister")
     ResponseEntity<String> deleteAccount(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
 
-    @Operation(summary = "회원 정보 조회", description = "사용자의 프로필 정보를 조회합니다.")
+    @Operation(summary = "회원 정보 조회", description = "사용자의 프로필 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("/profile")
     ResponseEntity<UserProfileResponse> getProfile(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
 
-    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/refresh-token")
     ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "Refresh Token") @RequestHeader("Authorization") String refreshToken);
+
+    @Operation(summary = "이름 변경", description = "사용자의 이름을 변경합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
+    @PostMapping("/change-name")
+    ResponseEntity<ChangeNameResponse> changeName(
+            @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
+            @Parameter(description = "변경할 새로운 이름") @RequestParam String newName);
 }

--- a/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
@@ -2,6 +2,7 @@ package club.gach_dong.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -16,34 +17,40 @@ import club.gach_dong.dto.response.UserProfileResponse;
 @RequestMapping("/api/v1")
 public interface AuthApiSpecification {
 
-    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 변경합니다.")
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 변경합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/change-password")
     ResponseEntity<String> changePassword(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
             @Parameter(description = "비밀번호 변경 정보") @Valid @RequestBody ChangePasswordRequest changePasswordRequest);
 
-    @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.")
+    @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/logout")
     ResponseEntity<String> logout(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
             @Parameter(description = "Refresh Token") @RequestHeader("Refresh-Token") String refreshToken);
 
-    @Operation(summary = "회원탈퇴", description = "사용자의 계정을 삭제합니다.")
+    @Operation(summary = "회원탈퇴", description = "사용자의 계정을 삭제합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/unregister")
     ResponseEntity<String> deleteAccount(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
 
-    @Operation(summary = "회원 정보 조회", description = "사용자의 프로필 정보를 조회합니다.")
+    @Operation(summary = "회원 정보 조회", description = "사용자의 프로필 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @GetMapping("/profile")
     ResponseEntity<UserProfileResponse> getProfile(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
 
-    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/refresh-token")
     ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "Refresh Token") @RequestHeader("Authorization") String refreshToken);
 
-    @Operation(summary = "이름 변경", description = "사용자의 이름을 변경합니다.")
+    @Operation(summary = "이름 변경", description = "사용자의 이름을 변경합니다.",
+            security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/change-name")
     ResponseEntity<ChangeNameResponse> changeName(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,

--- a/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import club.gach_dong.dto.request.ChangePasswordRequest;
+import club.gach_dong.dto.response.ChangeNameResponse;
 import club.gach_dong.dto.response.TokenResponse;
 import club.gach_dong.dto.response.UserProfileResponse;
 
@@ -41,4 +42,10 @@ public interface AuthApiSpecification {
     @PostMapping("/refresh-token")
     ResponseEntity<TokenResponse> refreshToken(
             @Parameter(description = "Refresh Token") @RequestHeader("Authorization") String refreshToken);
+
+    @Operation(summary = "이름 변경", description = "사용자의 이름을 변경합니다.")
+    @PostMapping("/change-name")
+    ResponseEntity<ChangeNameResponse> changeName(
+            @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token,
+            @Parameter(description = "변경할 새로운 이름") @RequestParam String newName);
 }

--- a/auth-service/src/main/java/club/gach_dong/controller/AdminAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AdminAuthController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import club.gach_dong.api.AdminAuthApiSpecification;
 import club.gach_dong.dto.request.ChangePasswordRequest;
 import club.gach_dong.dto.response.AuthResponse;
+import club.gach_dong.dto.response.ChangeNameResponse;
 import club.gach_dong.dto.response.TokenResponse;
 import club.gach_dong.dto.response.UserProfileResponse;
 import club.gach_dong.entity.Admin;
@@ -117,6 +118,26 @@ public class AdminAuthController implements AdminAuthApiSpecification {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(TokenResponse.withMessage("Access Token 재발급 실패: " + e.getMessage()));
+        }
+    }
+
+    @Override
+    public ResponseEntity<ChangeNameResponse> changeName(@RequestHeader("Authorization") String token, @RequestParam String newName) {
+        if (!jwtUtil.validateAdminToken(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        try {
+            String email = jwtUtil.getAdminEmailFromToken(token);
+            Admin admin = adminService.changeAdminName(email, newName);
+
+            if (admin != null) {
+                return ResponseEntity.ok(ChangeNameResponse.of(admin.getUserReferenceId(), newName));
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import club.gach_dong.api.AuthApiSpecification;
 import club.gach_dong.dto.request.ChangePasswordRequest;
+import club.gach_dong.dto.response.ChangeNameResponse;
 import club.gach_dong.dto.response.TokenResponse;
 import club.gach_dong.dto.response.UserProfileResponse;
 import club.gach_dong.entity.User;
@@ -116,6 +117,26 @@ public class AuthController implements AuthApiSpecification {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(TokenResponse.withMessage("Access Token 재발급 실패: " + e.getMessage()));
+        }
+    }
+
+    @Override
+    public ResponseEntity<ChangeNameResponse> changeName(@RequestHeader("Authorization") String token, @RequestParam String newName) {
+        if (!jwtUtil.validateUserToken(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        try {
+            String email = jwtUtil.getUserEmailFromToken(token);
+            User user = userService.changeUserName(email, newName);
+
+            if (user != null) {
+                return ResponseEntity.ok(ChangeNameResponse.of(user.getUserReferenceId(), newName));
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
     }
 }

--- a/auth-service/src/main/java/club/gach_dong/dto/response/ChangeNameResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/ChangeNameResponse.java
@@ -1,0 +1,15 @@
+package club.gach_dong.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ChangeNameResponse(
+        @Schema(description = "사용자 참조 ID", example = "user12345")
+        String userReferenceId,
+
+        @Schema(description = "변경된 사용자 이름", example = "변경한 이름")
+        String newName
+) {
+    public static ChangeNameResponse of(String userReferenceId, String newName) {
+        return new ChangeNameResponse(userReferenceId, newName);
+    }
+}

--- a/auth-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -160,7 +160,7 @@ public class AdminService {
     }
 
     public String getProfileImageUrl(String userReferenceId) {
-        String url = userServiceUrl + userReferenceId;
+        String url = userServiceUrl + "/api/v1/profile-image/" + userReferenceId;
 
         try {
             String profileImageUrl = restTemplate.getForObject(url, String.class);

--- a/auth-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -178,4 +178,13 @@ public class AdminService {
     public void updateAdminProfileImage(Admin admin) {
         adminRepository.save(admin);
     }
+
+    public Admin changeAdminName(String email, String newName) {
+        Admin admin = findByEmail(email);
+        if (admin != null) {
+            admin.setName(newName);
+            updateUser(admin);
+        }
+        return admin;
+    }
 }

--- a/auth-service/src/main/java/club/gach_dong/service/UserService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/UserService.java
@@ -179,7 +179,7 @@ public class UserService {
     }
 
     public String getProfileImageUrl(String userReferenceId) {
-        String url = userServiceUrl + userReferenceId;
+        String url = userServiceUrl + "/api/v1/profile-image/" + userReferenceId;
 
         try {
             String profileImageUrl = restTemplate.getForObject(url, String.class);

--- a/auth-service/src/main/java/club/gach_dong/service/UserService.java
+++ b/auth-service/src/main/java/club/gach_dong/service/UserService.java
@@ -197,4 +197,13 @@ public class UserService {
     public void updateUserProfileImage(User user) {
         userRepository.save(user);
     }
+
+    public User changeUserName(String email, String newName) {
+        User user = findByEmail(email);
+        if (user != null) {
+            user.setName(newName);
+            updateUser(user);
+        }
+        return user;
+    }
 }


### PR DESCRIPTION
## 1. 관련 이슈
#131 

## 2. 구현한 내용 또는 수정한 내용
- [x] 사용자 이름 변경 api 추가
- [x] 관리자 이름 변경 api 추가
- [x] AuthApiSpecification @SecurityRequirement 누락 수정
- [x] AdminAuthApiSpecification @SecurityRequirement 누락 수정
- [x] user-service와의 통신 URL 수정

## 3. TODO

## 4. 배포 전 Checklist
@EeeasyCode