### PR TITLE
[FIX] auth-service에서 refresh-token 관리 방법 수정 및 access-token 재발급 api 수정

### DIFF
--- a/auth-service/src/main/java/club/gach_dong/api/AdminAuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AdminAuthApiSpecification.java
@@ -43,7 +43,7 @@ public interface AdminAuthApiSpecification {
     ResponseEntity<UserProfileResponse> getProfile(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
 
-    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.",
+    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Refresh Token과 Access Token을 발급받습니다.",
             security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/refresh-token")
     ResponseEntity<TokenResponse> refreshToken(

--- a/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
+++ b/auth-service/src/main/java/club/gach_dong/api/AuthApiSpecification.java
@@ -43,7 +43,7 @@ public interface AuthApiSpecification {
     ResponseEntity<UserProfileResponse> getProfile(
             @Parameter(description = "JWT 토큰") @RequestHeader("Authorization") String token);
 
-    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.",
+    @Operation(summary = "Refresh Token 재발급", description = "유효한 Refresh Token을 사용하여 새로운 Refresh Token과 Access Token을 발급받습니다.",
             security = @SecurityRequirement(name = "Authorization"))
     @PostMapping("/refresh-token")
     ResponseEntity<TokenResponse> refreshToken(

--- a/auth-service/src/main/java/club/gach_dong/controller/AdminAuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AdminAuthController.java
@@ -114,12 +114,17 @@ public class AdminAuthController implements AdminAuthApiSpecification {
 
             String newAccessToken = jwtUtil.generateAdminToken(admin);
 
-            return ResponseEntity.ok(TokenResponse.of(newAccessToken));
+            String newRefreshToken = jwtUtil.generateAdminRefreshToken(admin);
+
+            jwtUtil.blacklistAdminRefreshToken(refreshToken);
+
+            return ResponseEntity.ok(TokenResponse.of(newAccessToken, newRefreshToken));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(TokenResponse.withMessage("Access Token 재발급 실패: " + e.getMessage()));
         }
     }
+
 
     @Override
     public ResponseEntity<ChangeNameResponse> changeName(@RequestHeader("Authorization") String token, @RequestParam String newName) {

--- a/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
+++ b/auth-service/src/main/java/club/gach_dong/controller/AuthController.java
@@ -113,7 +113,11 @@ public class AuthController implements AuthApiSpecification {
 
             String newAccessToken = jwtUtil.generateUserToken(user);
 
-            return ResponseEntity.ok(TokenResponse.of(newAccessToken));
+            String newRefreshToken = jwtUtil.generateUserRefreshToken(user);
+
+            jwtUtil.blacklistUserRefreshToken(refreshToken);
+
+            return ResponseEntity.ok(TokenResponse.of(newAccessToken, newRefreshToken));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(TokenResponse.withMessage("Access Token 재발급 실패: " + e.getMessage()));

--- a/auth-service/src/main/java/club/gach_dong/dto/response/TokenResponse.java
+++ b/auth-service/src/main/java/club/gach_dong/dto/response/TokenResponse.java
@@ -6,14 +6,17 @@ public record TokenResponse(
         @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
         String accessToken,
 
+        @Schema(description = "JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String refreshToken,
+
         @Schema(description = "응답 메시지", example = "Access Token 재발급 성공")
         String message
 ) {
-    public static TokenResponse of(String accessToken) {
-        return new TokenResponse(accessToken, "Access Token 재발급 성공");
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken, "Access Token 재발급 성공");
     }
 
     public static TokenResponse withMessage(String message) {
-        return new TokenResponse(null, message);
+        return new TokenResponse(null, null, message);
     }
 }


### PR DESCRIPTION
## 1. 관련 이슈

#137 

## 2. 구현한 내용 또는 수정한 내용

- [x] refresh-token을 발급할 때, redis에 저장하도록 수정
- [x] refresh-token의 redis 유효성 검증 추가
- [x] access-token 재발급 api에서 refresh-token도 재발급하도록 수정

## 3. TODO
access-token 재발급 api 사용 시, 헤더에 넣은 refresh-token은 이제 redis의 blacklist에 올라가기 때문에 재사용할 수 없습니다.

## 4. 배포 전 Checklist

@EeeasyCode 