### PR TITLE
[FEAT] Club Domain FE 요구사항 반영

### DIFF
--- a/club-service/src/main/java/club/gach_dong/api/ClubPublicApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubPublicApiSpecification.java
@@ -10,6 +10,8 @@ import club.gach_dong.dto.response.ClubSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -85,6 +87,8 @@ public interface ClubPublicApiSpecification {
             @Parameter(description = "동아리 ID", example = "1", required = true)
             @PathVariable Long clubId,
             @Parameter(description = "모집 공고 ID", example = "1", required = true)
-            @PathVariable Long recruitmentId
+            @PathVariable Long recruitmentId,
+            HttpServletRequest request,
+            HttpServletResponse response
     );
 }

--- a/club-service/src/main/java/club/gach_dong/api/ClubPublicApiSpecification.java
+++ b/club-service/src/main/java/club/gach_dong/api/ClubPublicApiSpecification.java
@@ -79,6 +79,18 @@ public interface ClubPublicApiSpecification {
     );
 
     @Operation(
+            summary = "동아리 별 모집 공고 조회 (내부 서비스 용)",
+            description = "특정 동아리의 모집 공고를 조회합니다."
+    )
+    @GetMapping("/inner-service/{clubId}/recruitments/{recruitmentId}")
+    ClubRecruitmentDetailResponse getClubRecruitmentsInService(
+            @Parameter(description = "동아리 ID", example = "1", required = true)
+            @PathVariable Long clubId,
+            @Parameter(description = "모집 공고 ID", example = "1", required = true)
+            @PathVariable Long recruitmentId
+    );
+
+    @Operation(
             summary = "특정 동아리 모집 공고 상세 조회",
             description = "특정 동아리의 특정 모집 공고를 조회합니다."
     )

--- a/club-service/src/main/java/club/gach_dong/controller/ClubPublicController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubPublicController.java
@@ -9,6 +9,9 @@ import club.gach_dong.dto.response.ClubRecruitmentResponse;
 import club.gach_dong.dto.response.ClubResponse;
 import club.gach_dong.dto.response.ClubSummaryResponse;
 import club.gach_dong.service.ClubReadService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -44,18 +47,21 @@ public class ClubPublicController implements ClubPublicApiSpecification {
 
     @Override
     public ArrayResponse<ClubRecruitmentResponse> getClubsRecruitments() {
-        List<ClubRecruitmentResponse> clubRecruitmentsResponse = clubReadService.getClubsRecruitments();
+        LocalDateTime currentTime = LocalDateTime.now();
+        List<ClubRecruitmentResponse> clubRecruitmentsResponse = clubReadService.getClubsRecruitments(currentTime);
         return ArrayResponse.of(clubRecruitmentsResponse);
     }
 
     @Override
     public ArrayResponse<ClubRecruitmentDetailResponse> getClubRecruitments(Long clubId) {
-        List<ClubRecruitmentDetailResponse> clubRecruitmentDetailResponse = clubReadService.getClubRecruitments(clubId);
+        LocalDateTime currentTime = LocalDateTime.now();
+        List<ClubRecruitmentDetailResponse> clubRecruitmentDetailResponse = clubReadService.getClubRecruitments(clubId, currentTime);
         return ArrayResponse.of(clubRecruitmentDetailResponse);
     }
 
     @Override
-    public ClubRecruitmentDetailResponse getClubRecruitment(Long clubId, Long recruitmentId) {
-        return clubReadService.getClubRecruitment(clubId, recruitmentId);
+    public ClubRecruitmentDetailResponse getClubRecruitment(Long clubId, Long recruitmentId, HttpServletRequest request, HttpServletResponse response) {
+        LocalDateTime currentTime = LocalDateTime.now();
+        return clubReadService.getClubRecruitment(clubId, recruitmentId, request, response, currentTime);
     }
 }

--- a/club-service/src/main/java/club/gach_dong/controller/ClubPublicController.java
+++ b/club-service/src/main/java/club/gach_dong/controller/ClubPublicController.java
@@ -60,6 +60,11 @@ public class ClubPublicController implements ClubPublicApiSpecification {
     }
 
     @Override
+    public ClubRecruitmentDetailResponse getClubRecruitmentsInService(Long clubId, Long recruitmentId) {
+        return clubReadService.getClubRecruitmentInService(clubId, recruitmentId);
+    }
+
+    @Override
     public ClubRecruitmentDetailResponse getClubRecruitment(Long clubId, Long recruitmentId, HttpServletRequest request, HttpServletResponse response) {
         LocalDateTime currentTime = LocalDateTime.now();
         return clubReadService.getClubRecruitment(clubId, recruitmentId, request, response, currentTime);

--- a/club-service/src/main/java/club/gach_dong/domain/Club.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Club.java
@@ -1,6 +1,5 @@
 package club.gach_dong.domain;
 
-import club.gach_dong.dto.request.UpdateClubRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/club-service/src/main/java/club/gach_dong/domain/Recruitment.java
+++ b/club-service/src/main/java/club/gach_dong/domain/Recruitment.java
@@ -37,7 +37,7 @@ public class Recruitment {
 
     @Column(name = "recruitment_status", nullable = false)
     @Schema(description = "모집 상태", example = "true")
-    private boolean recruitmentStatus = true;
+    private RecruitmentStatus recruitmentStatus = RecruitmentStatus.RECRUITING;
 
     @Column(name = "recruitment_count", nullable = false)
     @Schema(description = "모집 인원", example = "10")
@@ -61,6 +61,10 @@ public class Recruitment {
             "}")
     private Map<String, Object> processData;
 
+    @Column(name = "view_count", nullable = false)
+    @Schema(description = "조회수", example = "0")
+    private int viewCount = 0;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
@@ -79,5 +83,9 @@ public class Recruitment {
 
     public Boolean isRecruiting(LocalDateTime currentDateTime) {
         return currentDateTime.isBefore(this.endDate);
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
     }
 }

--- a/club-service/src/main/java/club/gach_dong/domain/RecruitmentStatus.java
+++ b/club-service/src/main/java/club/gach_dong/domain/RecruitmentStatus.java
@@ -1,0 +1,11 @@
+package club.gach_dong.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RecruitmentStatus {
+    RECRUITING("모집 중"),
+    RECRUITMENT_END("모집 종료");
+
+    private final String text;
+}

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentDetailResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentDetailResponse.java
@@ -2,6 +2,7 @@ package club.gach_dong.dto.response;
 
 import club.gach_dong.domain.Club;
 import club.gach_dong.domain.Recruitment;
+import club.gach_dong.domain.RecruitmentStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -29,7 +30,7 @@ public record ClubRecruitmentDetailResponse(
         Long applicationFormId,
         @Schema(description = "모집 상태", example = "true")
         @NotNull
-        boolean recruitmentStatus,
+        RecruitmentStatus recruitmentStatus,
         @Schema(description = "모집 프로세스 설정", example = "{\n" +
                 "  \"process1\": \"서류 심사\",\n" +
                 "  \"process2\": \"1차 면접\",\n" +
@@ -46,7 +47,7 @@ public record ClubRecruitmentDetailResponse(
         @NotNull
         LocalDateTime endDate
 ) {
-    public static ClubRecruitmentDetailResponse from(Club club, Recruitment recruitment) {
+    public static ClubRecruitmentDetailResponse from(Club club, Recruitment recruitment, RecruitmentStatus recruitmentStatus) {
         return new ClubRecruitmentDetailResponse(
                 club.getId(),
                 recruitment.getId(),
@@ -54,7 +55,7 @@ public record ClubRecruitmentDetailResponse(
                 recruitment.getContent(),
                 recruitment.getRecruitmentCount(),
                 recruitment.getApplicationFormId(),
-                recruitment.isRecruitmentStatus(),
+                recruitmentStatus,
                 recruitment.getProcessData(),
                 recruitment.getStartDate(),
                 recruitment.getEndDate()

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentDetailResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentDetailResponse.java
@@ -16,6 +16,9 @@ public record ClubRecruitmentDetailResponse(
         @Schema(description = "모집 ID", example = "1")
         @NotNull
         Long recruitmentId,
+        @Schema(description = "모집공고 조회수", example = "1")
+        @NotNull
+        int viewCount,
         @Schema(description = "모집공고 이름", example = "GDSC Gachon 24-25 Member 모집")
         @NotNull
         String title,
@@ -51,6 +54,7 @@ public record ClubRecruitmentDetailResponse(
         return new ClubRecruitmentDetailResponse(
                 club.getId(),
                 recruitment.getId(),
+                recruitment.getViewCount(),
                 recruitment.getTitle(),
                 recruitment.getContent(),
                 recruitment.getRecruitmentCount(),

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentResponse.java
@@ -3,6 +3,7 @@ package club.gach_dong.dto.response;
 import club.gach_dong.domain.Club;
 import club.gach_dong.domain.ClubCategory;
 import club.gach_dong.domain.Recruitment;
+import club.gach_dong.domain.RecruitmentStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -24,6 +25,9 @@ public record ClubRecruitmentResponse(
         @NotNull
         String clubName,
 
+        @Schema(description = "모집 상태", example = "RECRUITING")
+        @NotNull
+        RecruitmentStatus recruitmentStatus,
 
         @Schema(description = "동아리 이미지 URL", example = "https://gach-dong.club")
         @NotNull
@@ -46,12 +50,13 @@ public record ClubRecruitmentResponse(
         ClubCategory category
 
 ) {
-    public static ClubRecruitmentResponse from(Club club, Recruitment recruitment) {
+    public static ClubRecruitmentResponse from(Club club, Recruitment recruitment, RecruitmentStatus recruitmentStatus) {
         return new ClubRecruitmentResponse(
                 club.getId(),
                 recruitment.getId(),
                 recruitment.getTitle(),
                 club.getName(),
+                recruitmentStatus,
                 club.getClubImageUrl(),
                 recruitment.getApplicationFormId(),
                 recruitment.getStartDate(),

--- a/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentResponse.java
+++ b/club-service/src/main/java/club/gach_dong/dto/response/ClubRecruitmentResponse.java
@@ -17,6 +17,10 @@ public record ClubRecruitmentResponse(
         @NotNull
         Long recruitmentId,
 
+        @Schema(description = "조회수", example = "1")
+        @NotNull
+        int viewCount,
+
         @Schema(description = "모집공고 이름", example = "GDSC Gachon 24-25 Member 모집")
         @NotNull
         String title,
@@ -54,6 +58,7 @@ public record ClubRecruitmentResponse(
         return new ClubRecruitmentResponse(
                 club.getId(),
                 recruitment.getId(),
+                recruitment.getViewCount(),
                 recruitment.getTitle(),
                 club.getName(),
                 recruitmentStatus,

--- a/club-service/src/main/java/club/gach_dong/service/ClubReadService.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubReadService.java
@@ -125,6 +125,20 @@ public class ClubReadService {
         return ClubRecruitmentDetailResponse.from(club, recruitment, recruitmentStatus);
     }
 
+    public ClubRecruitmentDetailResponse getClubRecruitmentInService(Long clubId, Long recruitmentId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(ClubNotFoundException::new);
+
+        Recruitment recruitment = club.getRecruitment().stream()
+                .filter(r -> r.getId().equals(recruitmentId))
+                .findFirst()
+                .orElseThrow(RecruitmentNotFoundException::new);
+
+        RecruitmentStatus recruitmentStatus = updateStatusBasedOnTime(LocalDateTime.now(), recruitment.getEndDate());
+
+        return ClubRecruitmentDetailResponse.from(club, recruitment, recruitmentStatus);
+    }
+
     public Boolean hasAuthority(String userReferenceId, Long clubId) {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(ClubNotFoundException::new);

--- a/club-service/src/main/java/club/gach_dong/service/ClubService.java
+++ b/club-service/src/main/java/club/gach_dong/service/ClubService.java
@@ -99,6 +99,7 @@ public class ClubService {
         club.addRecruitment(recruitment);
         clubRepository.save(club);
 
+        // TODO: recruitment title is not unique
         Recruitment savedRecruitment = club.getRecruitment().stream()
                 .filter(r -> r.getTitle().equals(createClubRecruitmentRequest.title()))
                 .findFirst()


### PR DESCRIPTION
## 1. 관련 이슈

<!-- 연관된 이슈를 링크해주세요. -->

## 2. 구현한 내용 또는 수정한 내용
FE 요구사항이 추가됨에 따라, Club Domain의 기능이 추가되었습니다.
<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 혹은 gif 등을 활용해 자유롭게 보여주세요. -->

## 3. TODO
- [x] 동아리 모집 공고 Status 자동 계산 Response
- [x] 공고 조회수 기능 추가

## 4. 배포 전 Checklist
@opp-13 
1. 모집 공고 Status의 경우, 따로 DB의 필드를 수정하는 것이 아닌 API Call 요청 시 조회 시점의 시각과 모집 공고 마감일을 매번 계산하는 로직이 포함되어 있습니다. -> 추후 캐싱이나 좋은 방법으로 리팩터링 진행하겠습니다.
2. 공고 조회수 기능의 경우, 현재 조회한 postId가 cookie에 저장되어 조회수가 중복으로 늘어나는 것을 방지했습니다. -> 이것도 추후 더 좋은 방법으로 리팩터링 진행하겠습니다.
<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->