### PR TITLE
[FIX] Application Domain 지원 API Status 관련 Logic 수정

### DIFF
--- a/application-service/src/main/java/club/gach_dong/dto/response/ClubResponseDTO.java
+++ b/application-service/src/main/java/club/gach_dong/dto/response/ClubResponseDTO.java
@@ -1,0 +1,29 @@
+package club.gach_dong.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ClubResponseDTO {
+    @Getter
+    @Builder
+    @Schema(description = "내부 Service Mesh용 DTO (FrontEnd와는 관계가 없습니다.)")
+    public static class RecruitmentResponseDto {
+        private Long clubId;
+        private Long recruitmentId;
+        private Integer viewCount;
+        private String title;
+        private String content;
+        private Integer recruitmentCount;
+        private Long applicationFormId;
+        private String recruitmentStatus;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        @JsonProperty("processData")
+        private Map<String, String> processData;
+
+    }
+}

--- a/application-service/src/main/java/club/gach_dong/exception/ClubException.java
+++ b/application-service/src/main/java/club/gach_dong/exception/ClubException.java
@@ -15,4 +15,10 @@ public class ClubException {
             super(ErrorCode.CLUB_UNABLE_TO_REQUEST);
         }
     }
+
+    public static class ClubCommunicateFailedException extends DomainException {
+        public ClubCommunicateFailedException() {
+            super(ErrorCode.CLUB_UNABLE_TO_REQUEST);
+        }
+    }
 }

--- a/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
+++ b/application-service/src/main/java/club/gach_dong/repository/ApplicationRepository.java
@@ -20,7 +20,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     @Query("UPDATE application a SET a.applicationStatus = :status WHERE a = :application")
     void updateApplicationStatus(@Param("status") String status, @Param("application") Application application);
 
-    List<Application> findAllByRecruitmentIdAndApplicationStatus(Long recruitmentId, String status);
+    @Query("SELECT a FROM application a WHERE a.recruitmentId = :recruitmentId AND a.applicationStatus NOT IN ('TEMPORARY_SAVED')")
+    List<Application> findAllByRecruitmentIdAndApplicationStatus(@Param("recruitmentId") Long recruitmentId);
 
     Optional<Application> findByRecruitmentIdAndApplicationStatusAndUserId(Long recruitmentId, String status,
                                                                            String userId);

--- a/application-service/src/main/java/club/gach_dong/response/status/ErrorCode.java
+++ b/application-service/src/main/java/club/gach_dong/response/status/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     CLUB_UNAUTHORIZED("CLUBADMIN401", "인증이 필요합니다."),
     CLUB_UNABLE_TO_REQUEST("CLUBADMIN402", "클럽 서비스의 인증 요청이 실패했습니다."),
 
+    CLUB_UNABLE_TO_GET_PROCESS("CLUB401", "클럽 서비스의 신청 절차(Process)를 불러오는데 실패했습니다."),
+
     USER_NOT_FOUND("USER401", "사용자 ID를 찾을 수 없습니다."),
 
     APPLICATION_FORM_NOT_FOUND("APPLICATIONFORM401", "ApplicationForm이 없습니다."),

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -213,7 +213,7 @@ public class ApplicationService {
         }
 
         //If application couldn't be deleted.
-        if (Objects.equals(application.getApplicationStatus(), "SAVED")) {
+        if (!Objects.equals(application.getApplicationStatus(), "TEMPORARY_SAVED")) {
             throw new ApplicationNotChangeableException();
         }
 
@@ -280,8 +280,7 @@ public class ApplicationService {
         authorizationService.getAuthByUserIdAndApplyId(userId, recruitmentId);
 
         List<Application> applicationList = applicationRepository.findAllByRecruitmentIdAndApplicationStatus(
-                recruitmentId,
-                "SAVED");
+                recruitmentId);
 
         if (applicationList.isEmpty()) {
             return ApplicationResponseDTO.ToGetApplicationListAdminDTO.builder()

--- a/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ApplicationService.java
@@ -167,12 +167,19 @@ public class ApplicationService {
             }
         }
 
+        String applicationStatus = null;
+        if (!Objects.equals(toApplyClub.getStatus(), "TEMPORARY_SAVED")) {
+            applicationStatus = serviceMeshService.getFirstStatus(toApplyClub.getClubId(), recruitmentId);
+        } else {
+            applicationStatus = toApplyClub.getStatus();
+        }
+
         Application application = Application.builder()
                 .userId(userId)
                 .recruitmentId(recruitmentId)
                 .applicationFormId(toApplyClub.getApplicationFormId())
                 .applicationBody(toApplyClub.getFormBody())
-                .applicationStatus(toApplyClub.getStatus())
+                .applicationStatus(applicationStatus)
                 .clubId(toApplyClub.getClubId())
                 .submitDate(LocalDateTime.now())
                 .build();

--- a/application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java
+++ b/application-service/src/main/java/club/gach_dong/service/ServiceMeshService.java
@@ -58,7 +58,7 @@ public class ServiceMeshService {
     public String getFirstStatus(Long clubId, Long recruitmentId) {
 
         String uri = UriComponentsBuilder.fromHttpUrl(clubPublicUrl)
-                .path("/{clubId}/recruitments/{recruitmentId}")
+                .path("/inner-service/{clubId}/recruitments/{recruitmentId}")
                 .buildAndExpand(clubId, recruitmentId)
                 .toUriString();
         try {

--- a/application-service/src/main/resources/application.yaml
+++ b/application-service/src/main/resources/application.yaml
@@ -44,5 +44,6 @@ spring:
 msa:
   url:
     club: ${CLUB_URL}
+    clubPublic: ${CLUB_PUBLIC_URL}
     userDetail: ${USER_DETAIL_URL}
 


### PR DESCRIPTION
## 1. 관련 이슈
https://github.com/TEAM-YOAJUNG/backend-server/issues/144

## 2. 구현한 내용 또는 수정한 내용

1. 신청 시 ApplicationStatus 검증 관련 Logic에 SAVED 상태만 처리하는 문제가 있어 수정했습니다.
2. 신청 시(임시 저장이 아닐 경우) Club Service에서 첫번째 processData를 가져와 저장합니다.


#### ! https://github.com/TEAM-YOAJUNG/backend-server/pull/145 의 validateAndIncrementViewCount가 신청 시 발동될 수 있습니다. => 추후 조정 예정입니다.

## 3. TODO

- [x]  STATUS 검증 관련 Logic Error 수정
- [x] 초기 상태 불러오는 API 추가

## 4. 배포 전 Checklist

<!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->