### PR TITLE
[FIX] admin-service의 club-service api 호출 시 ResponseEntity 수정

### DIFF
--- a/admin-service/src/main/java/club/gach_dong/service/AdminService.java
+++ b/admin-service/src/main/java/club/gach_dong/service/AdminService.java
@@ -43,9 +43,9 @@ public class AdminService {
         String url = clubServiceUrl + "/admin/api/v1/authorize-admin";
 
         try {
-            ResponseEntity<Boolean> response = restTemplate.postForEntity(url, clubId, Boolean.class);
+            ResponseEntity<Void> response = restTemplate.postForEntity(url, clubId, Void.class);
 
-            if (!response.getStatusCode().is2xxSuccessful() || Boolean.FALSE.equals(response.getBody())) {
+            if (!response.getStatusCode().is2xxSuccessful()) {
                 throw new IllegalArgumentException("동아리 관리자 권한 부여 실패");
             }
 


### PR DESCRIPTION
## 1. 관련 이슈

#151 

## 2. 구현한 내용 또는 수정한 내용

-[x] club-service의 api 호출 시 기존의 ResponseEntity가 Boolean이였던 부분을 Void로 수정

## 3. TODO

## 4. 배포 전 Checklist
@EeeasyCode 